### PR TITLE
Added JTA support implemented by Narayana

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -88,6 +88,11 @@
                 <artifactId>kumuluzee-json-p-jsonp</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.kumuluz.ee</groupId>
+                <artifactId>kumuluzee-jta-narayana</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/components/jta/common/pom.xml
+++ b/components/jta/common/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kumuluzee-jta</artifactId>
+        <groupId>com.kumuluz.ee</groupId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>KumuluzEE JTA Common</name>
+    <description>KumuluzEE JTA component common utilities, configs and exceptions</description>
+
+    <artifactId>kumuluzee-jta-common</artifactId>
+
+    <properties>
+        <jta.version>1.2</jta.version>
+        <eclipselink.version>2.6.4</eclipselink.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-cdi-weld</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>javax.transaction-api</artifactId>
+            <version>${jta.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.json</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/JtaTransactionHolder.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/JtaTransactionHolder.java
@@ -1,0 +1,41 @@
+package com.kumuluz.ee.jta.common;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+import java.util.Objects;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.3.0
+ */
+public class JtaTransactionHolder {
+
+    private static final JtaTransactionHolder INSTANCE = new JtaTransactionHolder();
+    private TransactionAcquirer transactionAcquirer;
+
+    private JtaTransactionHolder() {
+    }
+
+    public static JtaTransactionHolder getInstance() {
+        return INSTANCE;
+    }
+
+    public void setTransactionAcquirer(TransactionAcquirer transactionAcquirer) {
+        this.transactionAcquirer = transactionAcquirer;
+    }
+
+    private void validateTransactionAcquirer() {
+        Objects.requireNonNull(transactionAcquirer, "TransactionAcquirer not found!");
+    }
+
+    public TransactionManager getTransactionManager() {
+        validateTransactionAcquirer();
+        return transactionAcquirer.getTransactionManager();
+    }
+
+    public UserTransaction getUserTransaction() {
+        validateTransactionAcquirer();
+        return transactionAcquirer.getUserTransaction();
+    }
+
+}

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/KumuluzTransactionServices.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/KumuluzTransactionServices.java
@@ -1,0 +1,50 @@
+package com.kumuluz.ee.jta.common;
+
+import org.jboss.weld.transaction.spi.TransactionServices;
+
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.3.0
+ */
+public class KumuluzTransactionServices implements TransactionServices {
+
+    private static final List<Integer> TRANSACTION_ACTIVE_STATUS = Arrays.asList(
+        Status.STATUS_ACTIVE, Status.STATUS_COMMITTING, Status.STATUS_MARKED_ROLLBACK, Status.STATUS_PREPARED,
+        Status.STATUS_PREPARING, Status.STATUS_ROLLING_BACK
+	);
+
+    @Override
+    public void registerSynchronization(Synchronization synchronizedObserver) {
+        try {
+            JtaTransactionHolder.getInstance().getTransactionManager().getTransaction().registerSynchronization(synchronizedObserver);
+        } catch (IllegalStateException | javax.transaction.RollbackException | SystemException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean isTransactionActive() {
+        try {
+            int status = JtaTransactionHolder.getInstance().getTransactionManager().getStatus();
+            return TRANSACTION_ACTIVE_STATUS.contains(status);
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public UserTransaction getUserTransaction() {
+        return JtaTransactionHolder.getInstance().getUserTransaction();
+    }
+
+    @Override
+    public void cleanup() {
+    }
+}

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/TransactionAcquirer.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/TransactionAcquirer.java
@@ -1,0 +1,16 @@
+package com.kumuluz.ee.jta.common;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.3.0
+ */
+public interface TransactionAcquirer {
+
+    UserTransaction getUserTransaction();
+
+    TransactionManager getTransactionManager();
+
+}

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/eclipselink/KumuluzPlatform.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/eclipselink/KumuluzPlatform.java
@@ -1,0 +1,21 @@
+package com.kumuluz.ee.jta.common.eclipselink;
+
+import org.eclipse.persistence.platform.server.ServerPlatformBase;
+import org.eclipse.persistence.sessions.DatabaseSession;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.3.0
+ */
+public class KumuluzPlatform extends ServerPlatformBase {
+
+    public KumuluzPlatform(DatabaseSession newDatabaseSession) {
+        super(newDatabaseSession);
+    }
+
+    @Override
+    public Class<?> getExternalTransactionControllerClass() {
+        return KumuluzTransactionController.class;
+    }
+
+}

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/eclipselink/KumuluzTransactionController.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/eclipselink/KumuluzTransactionController.java
@@ -1,0 +1,19 @@
+package com.kumuluz.ee.jta.common.eclipselink;
+
+import com.kumuluz.ee.jta.common.JtaTransactionHolder;
+import org.eclipse.persistence.transaction.JTATransactionController;
+
+import javax.transaction.TransactionManager;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.3.0
+ */
+public class KumuluzTransactionController extends JTATransactionController {
+
+    @Override
+    protected TransactionManager acquireTransactionManager() throws Exception {
+        return JtaTransactionHolder.getInstance().getTransactionManager();
+    }
+
+}

--- a/components/jta/common/src/main/resources/META-INF/services/org.jboss.weld.bootstrap.api.Service
+++ b/components/jta/common/src/main/resources/META-INF/services/org.jboss.weld.bootstrap.api.Service
@@ -1,0 +1,1 @@
+com.kumuluz.ee.jta.common.KumuluzTransactionServices

--- a/components/jta/narayana/pom.xml
+++ b/components/jta/narayana/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kumuluzee-jta</artifactId>
+        <groupId>com.kumuluz.ee</groupId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>KumuluzEE JTA Narayana</name>
+    <description>KumuluzEE JTA component implemented by Narayana</description>
+
+    <artifactId>kumuluzee-jta-narayana</artifactId>
+
+    <properties>
+        <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
+        <narayana.version>5.5.6.Final</narayana.version>
+        <eclipselink.version>2.6.4</eclipselink.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-jta-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-transaction-spi</artifactId>
+            <version>${jboss-transaction-spi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.narayana.jta</groupId>
+            <artifactId>narayana-jta</artifactId>
+            <version>${narayana.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/JtaComponent.java
+++ b/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/JtaComponent.java
@@ -1,0 +1,43 @@
+package com.kumuluz.ee.jta.narayana;
+
+
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.jta.utils.JNDIManager;
+import com.kumuluz.ee.common.Component;
+import com.kumuluz.ee.common.config.EeConfig;
+import com.kumuluz.ee.common.dependencies.EeComponentDef;
+import com.kumuluz.ee.common.dependencies.EeComponentType;
+import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
+import com.kumuluz.ee.jta.common.JtaTransactionHolder;
+
+import javax.naming.NamingException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.3.0
+ */
+@EeComponentDef(name = "Narayana JTA", type = EeComponentType.JTA)
+public class JtaComponent implements Component {
+
+    private Logger log = Logger.getLogger(JtaComponent.class.getSimpleName());
+
+    @Override
+    public void init(KumuluzServerWrapper server, EeConfig eeConfig) {
+        JtaTransactionHolder.getInstance().setTransactionAcquirer(new NarayanaTransactionAcquirer());
+    }
+
+    @Override
+    public void load() {
+        log.info("Initiating Narayana JTA");
+
+        arjPropertyManager.getObjectStoreEnvironmentBean().setObjectStoreDir("narayana");
+
+        try {
+            JNDIManager.bindJTAImplementation();
+        } catch (NamingException e) {
+            log.log(Level.WARNING, e.getMessage(), e);
+        }
+    }
+}

--- a/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaTransactionAcquirer.java
+++ b/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaTransactionAcquirer.java
@@ -1,0 +1,32 @@
+package com.kumuluz.ee.jta.narayana;
+
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import com.kumuluz.ee.jta.common.TransactionAcquirer;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.3.0
+ */
+public class NarayanaTransactionAcquirer implements TransactionAcquirer {
+
+    private JTAEnvironmentBean jtaEnvironment;
+
+    public NarayanaTransactionAcquirer() {
+        jtaEnvironment = jtaPropertyManager.getJTAEnvironmentBean();
+    }
+
+    @Override
+    public UserTransaction getUserTransaction() {
+        return jtaEnvironment.getUserTransaction();
+    }
+
+    @Override
+    public TransactionManager getTransactionManager() {
+        return jtaEnvironment.getTransactionManager();
+    }
+
+}

--- a/components/jta/narayana/src/main/resources/META-INF/services/com.kumuluz.ee.common.Component
+++ b/components/jta/narayana/src/main/resources/META-INF/services/com.kumuluz.ee.common.Component
@@ -1,0 +1,1 @@
+com.kumuluz.ee.jta.narayana.JtaComponent

--- a/components/jta/pom.xml
+++ b/components/jta/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kumuluzee-components</artifactId>
+        <groupId>com.kumuluz.ee</groupId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <modules>
+		<module>common</module>
+        <module>narayana</module>
+    </modules>
+
+    <name>KumuluzEE JTA</name>
+    <description>KumuluzEE JTA component</description>
+
+    <artifactId>kumuluzee-jta</artifactId>
+
+</project>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -25,6 +25,7 @@
         <module>bean-validation</module>
         <module>jax-ws</module>
         <module>ejb</module>
+        <module>jta</module>
     </modules>
 
     <artifactId>kumuluzee-components</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <beanvalidation.version>1.1.0.Final</beanvalidation.version>
         <json.p.version>1.0</json.p.version>
         <ejb.version>3.2</ejb.version>
+        <jta.version>1.2</jta.version>
 
         <jandex.version>2.0.3.Final</jandex.version>
         <hikari.version>2.6.1</hikari.version>
@@ -238,6 +239,16 @@
             </dependency>
             <dependency>
                 <groupId>com.kumuluz.ee</groupId>
+                <artifactId>kumuluzee-jta-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.kumuluz.ee</groupId>
+                <artifactId>kumuluzee-jta-narayana</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.kumuluz.ee</groupId>
                 <artifactId>kumuluzee-bom</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
@@ -324,6 +335,11 @@
                 <groupId>javax.ejb</groupId>
                 <artifactId>javax.ejb-api</artifactId>
                 <version>${ejb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.transaction</groupId>
+                <artifactId>javax.transaction-api</artifactId>
+                <version>${jta.version}</version>
             </dependency>
 
             <!-- Various libraries used throughout the framework-->


### PR DESCRIPTION
I liked Kumuluz and its simplicity and performance, however, I missed Java EE JTA support. I added JTA support through the Narayana implementation (JBoss Transaction) to Hibernate and EclipseLink.

Hibernate requires no extra settings to work with the JTA. On the other hand, the EclipseLink need add the following line in persistence.xml:
`<property name="eclipselink.target-server" value="com.kumuluz.ee.jta.common.eclipselink.KumuluzPlatform" />`