### PR TITLE
Fix the Weld’s problem not to print the stacktrace when a dependency was not satisfied

### DIFF
--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
@@ -30,6 +30,8 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.log.JavaUtilLog;
+import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.eclipse.jetty.webapp.Configuration;
@@ -62,6 +64,8 @@ public class JettyFactory {
     }
 
     public Server create() {
+
+        Log.setLog(new JavaUtilLog());
 
         Server server = new Server(createThreadPool());
 


### PR DESCRIPTION
I encountered problems with Weld whenever a dependency was not satisfied. Instead of printing in the console the error describing the dependency that can not be processed (like in Wildfly), Weld simply suppressed the stacktrace.

I was not able to get the stacktrace that described the problem with dependency injection configuring via log4j2.xml. According to the [CDI documentation](http://weld.cdi-spec.org/documentation/), Weld's debug logging should be enabled via [Jetty Logging](http://www.eclipse.org/jetty/documentation/current/configuring-logging.html) settings.

Here's my change to fix this problem with Jetty/Weld logging. If you can add to the project code or provide some way to set it via Config Extension, it would be very useful.
