### PR TITLE
Added SSL support for KumuluzEE. To enable SSL, users have to set the…

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/DataSourceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/DataSourceConfig.java
@@ -26,6 +26,60 @@ package com.kumuluz.ee.common.config;
  */
 public class DataSourceConfig {
 
+    public static class Builder {
+
+        private String jndiName;
+        private String driverClass;
+        private String connectionUrl;
+        private String username;
+        private String password;
+
+        private Integer maxPoolSize;
+
+        public Builder jndiName(String jndiName) {
+            this.jndiName = jndiName;
+            return this;
+        }
+
+        public Builder driverClass(String driverClass) {
+            this.driverClass = driverClass;
+            return this;
+        }
+
+        public Builder connectionUrl(String connectionUrl) {
+            this.connectionUrl = connectionUrl;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder maxPoolSize(Integer maxPoolSize) {
+            this.maxPoolSize = maxPoolSize;
+            return this;
+        }
+
+        public DataSourceConfig build() {
+
+            DataSourceConfig dataSourceConfig = new DataSourceConfig();
+            dataSourceConfig.jndiName = jndiName;
+            dataSourceConfig.driverClass = driverClass;
+            dataSourceConfig.connectionUrl = connectionUrl;
+            dataSourceConfig.username = username;
+            dataSourceConfig.password = password;
+            dataSourceConfig.maxPoolSize = maxPoolSize;
+
+            return dataSourceConfig;
+        }
+    }
+
     private String jndiName;
     private String driverClass;
     private String connectionUrl;
@@ -38,47 +92,23 @@ public class DataSourceConfig {
         return jndiName;
     }
 
-    public void setJndiName(String jndiName) {
-        this.jndiName = jndiName;
-    }
-
     public String getDriverClass() {
         return driverClass;
-    }
-
-    public void setDriverClass(String driverClass) {
-        this.driverClass = driverClass;
     }
 
     public String getConnectionUrl() {
         return connectionUrl;
     }
 
-    public void setConnectionUrl(String connectionUrl) {
-        this.connectionUrl = connectionUrl;
-    }
-
     public String getUsername() {
         return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
     }
 
     public String getPassword() {
         return password;
     }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
     public Integer getMaxPoolSize() {
         return maxPoolSize;
-    }
-
-    public void setMaxPoolSize(Integer maxPoolSize) {
-        this.maxPoolSize = maxPoolSize;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
@@ -24,7 +24,10 @@ import com.kumuluz.ee.common.utils.StringUtils;
 import com.kumuluz.ee.common.wrapper.EeComponentWrapper;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.ResourceBundle;
 
 /**
  * @author Tilen Faganel
@@ -44,9 +47,42 @@ public class EeConfig {
     public void init() {
         this.version = ResourceBundle.getBundle("version").getString("version");
 
-        persistenceConfigs.add(new PersistenceConfig());
-
         ConfigurationUtil cfg = ConfigurationUtil.getInstance();
+
+        Optional<List<String>> serverCfgOpt = cfg.getMapKeys("kumuluzee.server");
+        if (serverCfgOpt.isPresent()) {
+            serverConfig = new ServerConfig();
+
+            Optional<Integer> port = cfg.getInteger("kumuluzee.server.port");
+            Optional<Integer> minThreads = cfg.getInteger("kumuluzee.server.min-threads");
+            Optional<Integer> maxThreads = cfg.getInteger("kumuluzee.server.max-threads");
+            Optional<Integer> requestHeaderSize = cfg.getInteger("kumuluzee.server.request-header-size");
+            Optional<Integer> responseHeaderSize = cfg.getInteger("kumuluzee.server.response-header-size");
+            Optional<String> contextPath = cfg.get("kumuluzee.server.context-path");
+
+            Optional<Integer> sslPort = cfg.getInteger("kumuluzee.server.ssl-port");
+            Optional<String> keystorePath = cfg.get("kumuluzee.server.keystore-path");
+            Optional<String> keystorePassword = cfg.get("kumuluzee.server.keystore-password");
+            Optional<String> keymanagerPassword = cfg.get("kumuluzee.server.keymanager-password");
+            Optional<Boolean> enableSSL = cfg.getBoolean("kumuluzee.server.enable-ssl");
+            Optional<Boolean> forceSSL = cfg.getBoolean("kumuluzee.server.force-ssl");
+
+            port.ifPresent(serverConfig::setPort);
+            minThreads.ifPresent(serverConfig::setMinThreads);
+            maxThreads.ifPresent(serverConfig::setMaxThreads);
+            requestHeaderSize.ifPresent(serverConfig::setRequestHeaderSize);
+            responseHeaderSize.ifPresent(serverConfig::setResponseHeaderSize);
+            contextPath.ifPresent(serverConfig::setContextPath);
+
+            sslPort.ifPresent(serverConfig::setSSLPort);
+            keystorePath.ifPresent(serverConfig::setKeystorePath);
+            keystorePassword.ifPresent(serverConfig::setKeystorePassword);
+            keymanagerPassword.ifPresent(serverConfig::setKeyManagerPassword);
+            enableSSL.ifPresent(serverConfig::setEnableSSL);
+            forceSSL.ifPresent(serverConfig::setForceSSL);
+        }
+
+        persistenceConfigs.add(new PersistenceConfig());
 
         Optional<Integer> dsSizeOpt = cfg.getListSize("kumuluzee.datasources");
 

--- a/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
@@ -20,14 +20,10 @@
 */
 package com.kumuluz.ee.common.config;
 
-import com.kumuluz.ee.common.utils.StringUtils;
 import com.kumuluz.ee.common.wrapper.EeComponentWrapper;
-import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.ResourceBundle;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Tilen Faganel
@@ -35,124 +31,68 @@ import java.util.ResourceBundle;
  */
 public class EeConfig {
 
-    private String version;
+    public static class Builder {
 
-    private ServerConfig serverConfig = new ServerConfig();
-    private List<PersistenceConfig> persistenceConfigs = new ArrayList<>();
+        private ServerConfig.Builder server = new ServerConfig.Builder();
+        private List<DataSourceConfig.Builder> datasources = new ArrayList<>();
+        private List<XaDataSourceConfig.Builder> xaDatasources = new ArrayList<>();
+
+        public Builder server(ServerConfig.Builder server) {
+            this.server = server;
+            return this;
+        }
+
+        public Builder datasource(DataSourceConfig.Builder datasource) {
+            this.datasources.add(datasource);
+            return this;
+        }
+
+        public Builder xaDatasource(XaDataSourceConfig.Builder xaDatasource) {
+            this.xaDatasources.add(xaDatasource);
+            return this;
+        }
+
+        public EeConfig build() {
+
+            List<DataSourceConfig> constructedDatasources =
+                    datasources.stream().map(DataSourceConfig.Builder::build).collect(Collectors.toList());
+
+            List<XaDataSourceConfig> constructedXaDatasources =
+                    xaDatasources.stream().map(XaDataSourceConfig.Builder::build).collect(Collectors.toList());
+
+            EeConfig eeConfig = new EeConfig();
+            eeConfig.server = server.build();
+            eeConfig.datasources = Collections.unmodifiableList(constructedDatasources);
+            eeConfig.xaDatasources = Collections.unmodifiableList(constructedXaDatasources);
+
+            return eeConfig;
+        }
+    }
+
+    private ServerConfig server = new ServerConfig();
     private List<DataSourceConfig> datasources = new ArrayList<>();
     private List<XaDataSourceConfig> xaDatasources = new ArrayList<>();
 
+    private List<PersistenceConfig> persistenceConfigs = new ArrayList<>();
+
+    private String version;
     private List<EeComponentWrapper> eeComponents = new ArrayList<>();
 
-    public void init() {
+    public EeConfig() {
         this.version = ResourceBundle.getBundle("version").getString("version");
 
-        ConfigurationUtil cfg = ConfigurationUtil.getInstance();
-
-        Optional<List<String>> serverCfgOpt = cfg.getMapKeys("kumuluzee.server");
-        if (serverCfgOpt.isPresent()) {
-            serverConfig = new ServerConfig();
-
-            Optional<Integer> port = cfg.getInteger("kumuluzee.server.port");
-            Optional<Integer> minThreads = cfg.getInteger("kumuluzee.server.min-threads");
-            Optional<Integer> maxThreads = cfg.getInteger("kumuluzee.server.max-threads");
-            Optional<Integer> requestHeaderSize = cfg.getInteger("kumuluzee.server.request-header-size");
-            Optional<Integer> responseHeaderSize = cfg.getInteger("kumuluzee.server.response-header-size");
-            Optional<String> contextPath = cfg.get("kumuluzee.server.context-path");
-
-            Optional<Integer> sslPort = cfg.getInteger("kumuluzee.server.ssl-port");
-            Optional<String> keystorePath = cfg.get("kumuluzee.server.keystore-path");
-            Optional<String> keystorePassword = cfg.get("kumuluzee.server.keystore-password");
-            Optional<String> keymanagerPassword = cfg.get("kumuluzee.server.keymanager-password");
-            Optional<Boolean> enableSSL = cfg.getBoolean("kumuluzee.server.enable-ssl");
-            Optional<Boolean> forceSSL = cfg.getBoolean("kumuluzee.server.force-ssl");
-
-            port.ifPresent(serverConfig::setPort);
-            minThreads.ifPresent(serverConfig::setMinThreads);
-            maxThreads.ifPresent(serverConfig::setMaxThreads);
-            requestHeaderSize.ifPresent(serverConfig::setRequestHeaderSize);
-            responseHeaderSize.ifPresent(serverConfig::setResponseHeaderSize);
-            contextPath.ifPresent(serverConfig::setContextPath);
-
-            sslPort.ifPresent(serverConfig::setSSLPort);
-            keystorePath.ifPresent(serverConfig::setKeystorePath);
-            keystorePassword.ifPresent(serverConfig::setKeystorePassword);
-            keymanagerPassword.ifPresent(serverConfig::setKeyManagerPassword);
-            enableSSL.ifPresent(serverConfig::setEnableSSL);
-            forceSSL.ifPresent(serverConfig::setForceSSL);
-        }
-
         persistenceConfigs.add(new PersistenceConfig());
-
-        Optional<Integer> dsSizeOpt = cfg.getListSize("kumuluzee.datasources");
-
-        if (dsSizeOpt.isPresent()) {
-
-            for (int i = 0; i < dsSizeOpt.get(); i++) {
-
-                DataSourceConfig dsc = new DataSourceConfig();
-
-                Optional<String> jndiName = cfg.get("kumuluzee.datasources[" + i + "].jndi-name");
-                Optional<String> driverClass = cfg.get("kumuluzee.datasources[" + i + "].driver-class");
-                Optional<String> conUrl = cfg.get("kumuluzee.datasources[" + i + "].connection-url");
-                Optional<String> user = cfg.get("kumuluzee.datasources[" + i + "].username");
-                Optional<String> pass = cfg.get("kumuluzee.datasources[" + i + "].password");
-                Optional<Integer> maxPool = cfg.getInteger("kumuluzee.datasources[" + i + "].max-pool-size");
-
-                jndiName.ifPresent(dsc::setJndiName);
-                driverClass.ifPresent(dsc::setDriverClass);
-                conUrl.ifPresent(dsc::setConnectionUrl);
-                user.ifPresent(dsc::setUsername);
-                pass.ifPresent(dsc::setPassword);
-                maxPool.ifPresent(dsc::setMaxPoolSize);
-
-                datasources.add(dsc);
-            }
-        }
-
-        Optional<Integer> xDsSizeOpt = cfg.getListSize("kumuluzee.xa-datasources");
-
-        if (xDsSizeOpt.isPresent()) {
-
-            for (int i = 0; i < xDsSizeOpt.get(); i++) {
-
-                XaDataSourceConfig xdsc = new XaDataSourceConfig();
-
-                Optional<String> jndiName = cfg.get("kumuluzee.xa-datasources[" + i + "].jndi-name");
-                Optional<String> xaDatasourceClass = cfg.get("kumuluzee.xa-datasources[" + i + "].xa-datasource-class");
-                Optional<String> user = cfg.get("kumuluzee.xa-datasources[" + i + "].username");
-                Optional<String> pass = cfg.get("kumuluzee.xa-datasources[" + i + "].password");
-
-                jndiName.ifPresent(xdsc::setJndiName);
-                xaDatasourceClass.ifPresent(xdsc::setXaDatasourceClass);
-                user.ifPresent(xdsc::setUsername);
-                pass.ifPresent(xdsc::setPassword);
-
-                Optional<List<String>> props = cfg.getMapKeys("kumuluzee.xa-datasources[" + i + "].props");
-
-                if (props.isPresent()) {
-
-                    for (String propName : props.get()) {
-
-                        Optional<String> propValue = cfg.get("kumuluzee.xa-datasources[" + i + "].props." + propName);
-
-                        propValue.ifPresent(v -> xdsc.getProps().put(StringUtils.hyphenCaseToCamelCase(propName), v));
-                    }
-                }
-
-                xaDatasources.add(xdsc);
-            }
-        }
     }
 
     public String getVersion() {
         return version;
     }
 
-    public ServerConfig getServerConfig() {
-        return serverConfig;
+    public ServerConfig getServer() {
+        return server;
     }
 
+    @Deprecated
     public List<PersistenceConfig> getPersistenceConfigs() {
         return persistenceConfigs;
     }

--- a/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
@@ -78,6 +78,8 @@ public class EeConfig {
         }
     }
 
+    private static EeConfig instance;
+
     private ServerConfig server = new ServerConfig();
     private List<DataSourceConfig> datasources = new ArrayList<>();
     private List<XaDataSourceConfig> xaDatasources = new ArrayList<>();
@@ -89,6 +91,24 @@ public class EeConfig {
 
     public EeConfig() {
         this.version = ResourceBundle.getBundle("version").getString("version");
+    }
+
+    public static void initialize(EeConfig eeConfig) {
+
+        if (instance != null) {
+            throw new IllegalStateException("The EeConfig was already initialized.");
+        }
+
+        instance = eeConfig;
+    }
+
+    public static EeConfig getInstance() {
+
+        if (instance == null) {
+            throw new IllegalStateException("The EeConfig was not yet initialized.");
+        }
+
+        return instance;
     }
 
     public String getVersion() {

--- a/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
@@ -37,6 +37,8 @@ public class EeConfig {
         private List<DataSourceConfig.Builder> datasources = new ArrayList<>();
         private List<XaDataSourceConfig.Builder> xaDatasources = new ArrayList<>();
 
+        private PersistenceConfig.Builder persistenceConfig = new PersistenceConfig.Builder();
+
         public Builder server(ServerConfig.Builder server) {
             this.server = server;
             return this;
@@ -49,6 +51,11 @@ public class EeConfig {
 
         public Builder xaDatasource(XaDataSourceConfig.Builder xaDatasource) {
             this.xaDatasources.add(xaDatasource);
+            return this;
+        }
+
+        public Builder persistenceConfig(PersistenceConfig.Builder persistenceConfig) {
+            this.persistenceConfig = persistenceConfig;
             return this;
         }
 
@@ -65,6 +72,8 @@ public class EeConfig {
             eeConfig.datasources = Collections.unmodifiableList(constructedDatasources);
             eeConfig.xaDatasources = Collections.unmodifiableList(constructedXaDatasources);
 
+            eeConfig.persistenceConfig = persistenceConfig.build();
+
             return eeConfig;
         }
     }
@@ -73,15 +82,13 @@ public class EeConfig {
     private List<DataSourceConfig> datasources = new ArrayList<>();
     private List<XaDataSourceConfig> xaDatasources = new ArrayList<>();
 
-    private List<PersistenceConfig> persistenceConfigs = new ArrayList<>();
+    private PersistenceConfig persistenceConfig;
 
     private String version;
     private List<EeComponentWrapper> eeComponents = new ArrayList<>();
 
     public EeConfig() {
         this.version = ResourceBundle.getBundle("version").getString("version");
-
-        persistenceConfigs.add(new PersistenceConfig());
     }
 
     public String getVersion() {
@@ -90,11 +97,6 @@ public class EeConfig {
 
     public ServerConfig getServer() {
         return server;
-    }
-
-    @Deprecated
-    public List<PersistenceConfig> getPersistenceConfigs() {
-        return persistenceConfigs;
     }
 
     public List<DataSourceConfig> getDatasources() {
@@ -107,5 +109,10 @@ public class EeConfig {
 
     public List<EeComponentWrapper> getEeComponents() {
         return eeComponents;
+    }
+
+    @Deprecated
+    public PersistenceConfig getPersistenceConfig() {
+        return persistenceConfig;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/PersistenceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/PersistenceConfig.java
@@ -26,61 +26,66 @@ import com.kumuluz.ee.common.utils.EnvUtils;
  * @author Tilen Faganel
  * @since 1.0.0
  */
+@Deprecated
 public class PersistenceConfig {
 
-    public static final String DB_UNIT_ENV = "DATABASE_UNIT";
+    public static class Builder {
 
-    public static final String DB_URL_ENV = "DATABASE_URL";
+        private String unitName;
+        private String url;
+        private String username;
+        private String password;
 
-    public static final String DB_USER_ENV = "DATABASE_USER";
+        public Builder unitName(String unitName) {
+            this.unitName = unitName;
+            return this;
+        }
 
-    public static final String DB_PASS_ENV = "DATABASE_PASS";
+        public Builder url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public PersistenceConfig build() {
+
+            PersistenceConfig persistenceConfig = new PersistenceConfig();
+            persistenceConfig.unitName = unitName;
+            persistenceConfig.url = url;
+            persistenceConfig.username = username;
+            persistenceConfig.password = password;
+
+            return persistenceConfig;
+        }
+    }
 
     private String unitName;
-
     private String url;
-
     private String username;
-
     private String password;
-
-    public PersistenceConfig() {
-
-        EnvUtils.getEnv(DB_UNIT_ENV, this::setUnitName);
-        EnvUtils.getEnv(DB_URL_ENV, this::setUrl);
-        EnvUtils.getEnv(DB_USER_ENV, this::setUsername);
-        EnvUtils.getEnv(DB_PASS_ENV, this::setPassword);
-    }
 
     public String getUnitName() {
         return unitName;
-    }
-
-    public void setUnitName(String unitName) {
-        this.unitName = unitName;
     }
 
     public String getUrl() {
         return url;
     }
 
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
     public String getUsername() {
         return username;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
     public String getPassword() {
         return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -207,9 +207,4 @@ public class ServerConfig {
     public void setForceSSL(Boolean forceSSL) {
         this.forceSSL = forceSSL;
     }
-
-    private String getDefaultKeystorePath() {
-        String jrePath = System.getProperty("java.home");
-        return keystorePath;
-    }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -30,6 +30,8 @@ public class ServerConfig {
 
     public static final String PORT_ENV = "PORT";
 
+    public static final String SSL_PORT_ENV = "SSL_PORT";
+
     public static final String MIN_THREADS_ENV = "MIN_THREADS";
 
     public static final String MAX_THREADS_ENV = "MAX_THREADS";
@@ -40,7 +42,19 @@ public class ServerConfig {
 
     public static final String CONTEXT_PATH_ENV = "CONTEXT_PATH";
 
+    public static final String KEYSTORE_PATH_ENV = "KEYSTORE_PATH";
+
+    public static final String KEYSTORE_PASSWORD_ENV = "KEYSTORE_PASSWORD";
+
+    public static final String KEY_MANAGER_PASS_ENV = "KEY_MANAGER_PASSWORD";
+
+    public static final String ENABLE_SSL_ENV = "ENABLE_SSL";
+
+    public static final String FORCE_SSL_ENV = "FORCE_SSL";
+
     private Integer port = 8080;
+
+    private Integer sslPort = 8443;
 
     private String contextPath = "/";
 
@@ -56,14 +70,30 @@ public class ServerConfig {
 
     private Integer responseHeaderSize = 8 * 1024;
 
+    private String keystorePath = System.getProperty("javax.net.ssl.keyStore");
+
+    private String keystorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+
+    private String keyManagerPassword;
+
+    private Boolean enableSSL = false;
+
+    private Boolean forceSSL = false;
+
     public ServerConfig() {
 
         EnvUtils.getEnvAsInteger(PORT_ENV, this::setPort);
+        EnvUtils.getEnvAsInteger(SSL_PORT_ENV, this::setSSLPort);
         EnvUtils.getEnvAsInteger(MIN_THREADS_ENV, this::setMinThreads);
         EnvUtils.getEnvAsInteger(MAX_THREADS_ENV, this::setMaxThreads);
         EnvUtils.getEnvAsInteger(REQUEST_HEADER_SIZE, this::setRequestHeaderSize);
         EnvUtils.getEnvAsInteger(RESPONSE_HEADER_SIZE, this::setResponseHeaderSize);
         EnvUtils.getEnv(CONTEXT_PATH_ENV, this::setContextPath);
+        EnvUtils.getEnv(KEYSTORE_PATH_ENV, this::setKeystorePath);
+        EnvUtils.getEnv(KEYSTORE_PASSWORD_ENV, this::setKeystorePassword);
+        EnvUtils.getEnv(KEY_MANAGER_PASS_ENV, this::setKeyManagerPassword);
+        EnvUtils.getEnvAsBoolean(ENABLE_SSL_ENV, this::setEnableSSL);
+        EnvUtils.getEnvAsBoolean(FORCE_SSL_ENV, this::setForceSSL);
     }
 
     public Integer getPort() {
@@ -72,6 +102,14 @@ public class ServerConfig {
 
     public void setPort(Integer port) {
         this.port = port;
+    }
+
+    public Integer getSSLPort() {
+        return sslPort;
+    }
+
+    public void setSSLPort(Integer sslPort) {
+        this.sslPort = sslPort;
     }
 
     public String getContextPath() {
@@ -128,5 +166,50 @@ public class ServerConfig {
 
     public void setResponseHeaderSize(Integer responseHeaderSize) {
         this.responseHeaderSize = responseHeaderSize;
+    }
+
+    public String getKeystorePath() {
+        return keystorePath;
+    }
+
+    public void setKeystorePath(String keystorePath) {
+        this.keystorePath = keystorePath;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public void setKeystorePassword(String keystorePassword) {
+        this.keystorePassword = keystorePassword;
+    }
+
+    public String getKeyManagerPassword() {
+        return keyManagerPassword;
+    }
+
+    public void setKeyManagerPassword(String keyManagerPassword) {
+        this.keyManagerPassword = keyManagerPassword;
+    }
+
+    public Boolean getEnableSSL() {
+        return enableSSL;
+    }
+
+    public void setEnableSSL(Boolean enableSSL) {
+        this.enableSSL = enableSSL;
+    }
+
+    public Boolean getForceSSL() {
+        return forceSSL;
+    }
+
+    public void setForceSSL(Boolean forceSSL) {
+        this.forceSSL = forceSSL;
+    }
+
+    private String getDefaultKeystorePath() {
+        String jrePath = System.getProperty("java.home");
+        return keystorePath;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -26,146 +26,90 @@ package com.kumuluz.ee.common.config;
  */
 public class ServerConfig {
 
-    private Integer port = 8080;
+    public static class Builder {
 
-    private Integer sslPort = 8443;
+        private String contextPath = "/";
+        private Integer minThreads = 5;
+        private Integer maxThreads = 100;
+        private Boolean forceHttps = false;
 
-    private String contextPath = "/";
+        private ServerConnectorConfig.Builder http = new ServerConnectorConfig.Builder();
+        private ServerConnectorConfig.Builder https = new ServerConnectorConfig.Builder();
 
-    private Integer idleTimeout = 60 * 60 * 1000;
+        public Builder contextPath(String contextPath) {
+            this.contextPath = contextPath;
+            return this;
+        }
 
-    private Integer soLingerTime = -1;
+        public Builder minThreads(Integer minThreads) {
+            this.minThreads = minThreads;
+            return this;
+        }
 
-    private Integer minThreads = 5;
+        public Builder maxThreads(Integer maxThreads) {
+            this.maxThreads = maxThreads;
+            return this;
+        }
 
-    private Integer maxThreads = 100;
+        public Builder forceHttps(Boolean forceHttps) {
+            this.forceHttps = forceHttps;
+            return this;
+        }
 
-    private Integer requestHeaderSize = 8 * 1024;
+        public Builder http(ServerConnectorConfig.Builder http) {
+            this.http = http;
+            return this;
+        }
 
-    private Integer responseHeaderSize = 8 * 1024;
+        public Builder https(ServerConnectorConfig.Builder https) {
+            this.https = https;
+            return this;
+        }
 
-    private String keystorePath = System.getProperty("javax.net.ssl.keyStore");
+        public ServerConfig build() {
 
-    private String keystorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.contextPath = contextPath;
+            serverConfig.minThreads = minThreads;
+            serverConfig.maxThreads = maxThreads;
+            serverConfig.forceHttps = forceHttps;
 
-    private String keyManagerPassword;
+            serverConfig.http = http.build();
+            serverConfig.https = https.build();
 
-    private Boolean enableSSL = false;
-
-    private Boolean forceSSL = false;
-
-    public ServerConfig() {
+            return serverConfig;
+        }
     }
 
-    public Integer getPort() {
-        return port;
-    }
+    private String contextPath;
+    private Integer minThreads;
+    private Integer maxThreads;
+    private Boolean forceHttps;
 
-    public void setPort(Integer port) {
-        this.port = port;
-    }
-
-    public Integer getSSLPort() {
-        return sslPort;
-    }
-
-    public void setSSLPort(Integer sslPort) {
-        this.sslPort = sslPort;
-    }
+    private ServerConnectorConfig http;
+    private ServerConnectorConfig https;
 
     public String getContextPath() {
         return contextPath;
-    }
-
-    public void setContextPath(String contextPath) {
-        this.contextPath = contextPath;
-    }
-
-    public Integer getIdleTimeout() {
-        return idleTimeout;
-    }
-
-    public void setIdleTimeout(Integer idleTimeout) {
-        this.idleTimeout = idleTimeout;
-    }
-
-    public Integer getSoLingerTime() {
-        return soLingerTime;
-    }
-
-    public void setSoLingerTime(Integer soLingerTime) {
-        this.soLingerTime = soLingerTime;
     }
 
     public Integer getMinThreads() {
         return minThreads;
     }
 
-    public void setMinThreads(Integer minThreads) {
-        this.minThreads = minThreads;
-    }
-
     public Integer getMaxThreads() {
         return maxThreads;
     }
 
-    public void setMaxThreads(Integer maxThreads) {
-        this.maxThreads = maxThreads;
+    public Boolean getForceHttps() {
+        return forceHttps;
     }
 
-    public Integer getRequestHeaderSize() {
-        return requestHeaderSize;
+    public ServerConnectorConfig getHttp() {
+        return http;
     }
 
-    public void setRequestHeaderSize(Integer requestHeaderSize) {
-        this.requestHeaderSize = requestHeaderSize;
-    }
-
-    public Integer getResponseHeaderSize() {
-        return responseHeaderSize;
-    }
-
-    public void setResponseHeaderSize(Integer responseHeaderSize) {
-        this.responseHeaderSize = responseHeaderSize;
-    }
-
-    public String getKeystorePath() {
-        return keystorePath;
-    }
-
-    public void setKeystorePath(String keystorePath) {
-        this.keystorePath = keystorePath;
-    }
-
-    public String getKeystorePassword() {
-        return keystorePassword;
-    }
-
-    public void setKeystorePassword(String keystorePassword) {
-        this.keystorePassword = keystorePassword;
-    }
-
-    public String getKeyManagerPassword() {
-        return keyManagerPassword;
-    }
-
-    public void setKeyManagerPassword(String keyManagerPassword) {
-        this.keyManagerPassword = keyManagerPassword;
-    }
-
-    public Boolean getEnableSSL() {
-        return enableSSL;
-    }
-
-    public void setEnableSSL(Boolean enableSSL) {
-        this.enableSSL = enableSSL;
-    }
-
-    public Boolean getForceSSL() {
-        return forceSSL;
-    }
-
-    public void setForceSSL(Boolean forceSSL) {
-        this.forceSSL = forceSSL;
+    public ServerConnectorConfig getHttps() {
+        return https;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -20,37 +20,11 @@
 */
 package com.kumuluz.ee.common.config;
 
-import com.kumuluz.ee.common.utils.EnvUtils;
-
 /**
  * @author Tilen Faganel
  * @since 1.0.0
  */
 public class ServerConfig {
-
-    public static final String PORT_ENV = "PORT";
-
-    public static final String SSL_PORT_ENV = "SSL_PORT";
-
-    public static final String MIN_THREADS_ENV = "MIN_THREADS";
-
-    public static final String MAX_THREADS_ENV = "MAX_THREADS";
-
-    public static final String REQUEST_HEADER_SIZE = "REQUEST_HEADER_SIZE";
-
-    public static final String RESPONSE_HEADER_SIZE = "RESPONSE_HEADER_SIZE";
-
-    public static final String CONTEXT_PATH_ENV = "CONTEXT_PATH";
-
-    public static final String KEYSTORE_PATH_ENV = "KEYSTORE_PATH";
-
-    public static final String KEYSTORE_PASSWORD_ENV = "KEYSTORE_PASSWORD";
-
-    public static final String KEY_MANAGER_PASS_ENV = "KEY_MANAGER_PASSWORD";
-
-    public static final String ENABLE_SSL_ENV = "ENABLE_SSL";
-
-    public static final String FORCE_SSL_ENV = "FORCE_SSL";
 
     private Integer port = 8080;
 
@@ -81,19 +55,6 @@ public class ServerConfig {
     private Boolean forceSSL = false;
 
     public ServerConfig() {
-
-        EnvUtils.getEnvAsInteger(PORT_ENV, this::setPort);
-        EnvUtils.getEnvAsInteger(SSL_PORT_ENV, this::setSSLPort);
-        EnvUtils.getEnvAsInteger(MIN_THREADS_ENV, this::setMinThreads);
-        EnvUtils.getEnvAsInteger(MAX_THREADS_ENV, this::setMaxThreads);
-        EnvUtils.getEnvAsInteger(REQUEST_HEADER_SIZE, this::setRequestHeaderSize);
-        EnvUtils.getEnvAsInteger(RESPONSE_HEADER_SIZE, this::setResponseHeaderSize);
-        EnvUtils.getEnv(CONTEXT_PATH_ENV, this::setContextPath);
-        EnvUtils.getEnv(KEYSTORE_PATH_ENV, this::setKeystorePath);
-        EnvUtils.getEnv(KEYSTORE_PASSWORD_ENV, this::setKeystorePassword);
-        EnvUtils.getEnv(KEY_MANAGER_PASS_ENV, this::setKeyManagerPassword);
-        EnvUtils.getEnvAsBoolean(ENABLE_SSL_ENV, this::setEnableSSL);
-        EnvUtils.getEnvAsBoolean(FORCE_SSL_ENV, this::setForceSSL);
     }
 
     public Integer getPort() {

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
@@ -34,6 +34,7 @@ public class ServerConnectorConfig {
         private Integer port;
         private String address;
         private Boolean enabled;
+        private Boolean http2 = false;
         private Boolean proxyForwarding = false;
         private Integer requestHeaderSize = 8 * 1024;
         private Integer responseHeaderSize = 8 * 1024;
@@ -57,6 +58,11 @@ public class ServerConnectorConfig {
 
         public Builder enabled(Boolean enabled) {
             this.enabled = enabled;
+            return this;
+        }
+
+        public Builder http2(Boolean http2) {
+            this.http2 = http2;
             return this;
         }
 
@@ -111,6 +117,7 @@ public class ServerConnectorConfig {
             serverConnectorConfig.port = port;
             serverConnectorConfig.address = address;
             serverConnectorConfig.enabled = enabled;
+            serverConnectorConfig.http2 = http2;
             serverConnectorConfig.proxyForwarding = proxyForwarding;
             serverConnectorConfig.requestHeaderSize = requestHeaderSize;
             serverConnectorConfig.responseHeaderSize = responseHeaderSize;
@@ -128,6 +135,7 @@ public class ServerConnectorConfig {
     private Integer port;
     private String address;
     private Boolean enabled;
+    private Boolean http2;
     private Boolean proxyForwarding;
     private Integer requestHeaderSize;
     private Integer responseHeaderSize;
@@ -149,6 +157,10 @@ public class ServerConnectorConfig {
 
     public Boolean getEnabled() {
         return enabled;
+    }
+
+    public Boolean getHttp2() {
+        return http2;
     }
 
     public Boolean getProxyForwarding() {

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
@@ -1,0 +1,157 @@
+package com.kumuluz.ee.common.config;
+
+/**
+ * @author Tilen Faganel
+ * @since 2.4.0
+ */
+public class ServerConnectorConfig {
+
+    public static class Builder {
+
+        public final static Integer DEFAULT_HTTP_PORT = 8080;
+        public final static Integer DEFAULT_HTTPS_PORT = 8443;
+
+        private Integer port;
+        private String address;
+        private Boolean enabled;
+        private Integer requestHeaderSize = 8 * 1024;
+        private Integer responseHeaderSize = 8 * 1024;
+        private Integer idleTimeout = 60 * 60 * 1000;
+        private Integer soLingerTime = -1;
+
+        private String keystorePath = System.getProperty("javax.net.ssl.keyStore");
+        private String keystorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+        private String keyAlias;
+        private String keyPassword;
+
+        public Builder port(Integer port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder address(String address) {
+            this.address = address;
+            return this;
+        }
+
+        public Builder enabled(Boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder requestHeaderSize(Integer requestHeaderSize) {
+            this.requestHeaderSize = requestHeaderSize;
+            return this;
+        }
+
+        public Builder responseHeaderSize(Integer responseHeaderSize) {
+            this.responseHeaderSize = responseHeaderSize;
+            return this;
+        }
+
+        public Builder idleTimeout(Integer idleTimeout) {
+            this.idleTimeout = idleTimeout;
+            return this;
+        }
+
+        public Builder soLingerTime(Integer soLingerTime) {
+            this.soLingerTime = soLingerTime;
+            return this;
+        }
+
+        public Builder keystorePath(String keystorePath) {
+            this.keystorePath = keystorePath;
+            return this;
+        }
+
+        public Builder keystorePassword(String keystorePassword) {
+            this.keystorePassword = keystorePassword;
+            return this;
+        }
+
+        public Builder keyAlias(String keyAlias) {
+            this.keyAlias = keyAlias;
+            return this;
+        }
+
+        public Builder keyPassword(String keyPassword) {
+            this.keyPassword = keyPassword;
+            return this;
+        }
+
+        public ServerConnectorConfig build() {
+
+            ServerConnectorConfig serverConnectorConfig = new ServerConnectorConfig();
+            serverConnectorConfig.port = port;
+            serverConnectorConfig.address = address;
+            serverConnectorConfig.enabled = enabled;
+            serverConnectorConfig.requestHeaderSize = requestHeaderSize;
+            serverConnectorConfig.responseHeaderSize = responseHeaderSize;
+            serverConnectorConfig.idleTimeout = idleTimeout;
+            serverConnectorConfig.soLingerTime = soLingerTime;
+            serverConnectorConfig.keystorePath = keystorePath;
+            serverConnectorConfig.keystorePassword = keystorePassword;
+            serverConnectorConfig.keyAlias = keyAlias;
+            serverConnectorConfig.keyPassword = keyPassword;
+
+            return serverConnectorConfig;
+        }
+    }
+
+    private Integer port;
+    private String address;
+    private Boolean enabled;
+    private Integer requestHeaderSize;
+    private Integer responseHeaderSize;
+    private Integer idleTimeout;
+    private Integer soLingerTime;
+
+    private String keystorePath;
+    private String keystorePassword;
+    private String keyAlias;
+    private String keyPassword;
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public Integer getRequestHeaderSize() {
+        return requestHeaderSize;
+    }
+
+    public Integer getResponseHeaderSize() {
+        return responseHeaderSize;
+    }
+
+    public Integer getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    public Integer getSoLingerTime() {
+        return soLingerTime;
+    }
+
+    public String getKeystorePath() {
+        return keystorePath;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public String getKeyAlias() {
+        return keyAlias;
+    }
+
+    public String getKeyPassword() {
+        return keyPassword;
+    }
+}

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
@@ -20,6 +20,9 @@
 */
 package com.kumuluz.ee.common.config;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * @author Tilen Faganel
  * @since 2.4.0
@@ -45,6 +48,8 @@ public class ServerConnectorConfig {
         private String keystorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
         private String keyAlias;
         private String keyPassword;
+        private List<String> sslProtocols;
+        private List<String> sslCiphers;
 
         public Builder port(Integer port) {
             this.port = port;
@@ -111,6 +116,16 @@ public class ServerConnectorConfig {
             return this;
         }
 
+        public Builder sslProtocols(List<String> sslProtocols) {
+            this.sslProtocols = Collections.unmodifiableList(sslProtocols);
+            return this;
+        }
+
+        public Builder sslCiphers(List<String> sslCiphers) {
+            this.sslCiphers = Collections.unmodifiableList(sslCiphers);
+            return this;
+        }
+
         public ServerConnectorConfig build() {
 
             ServerConnectorConfig serverConnectorConfig = new ServerConnectorConfig();
@@ -127,6 +142,8 @@ public class ServerConnectorConfig {
             serverConnectorConfig.keystorePassword = keystorePassword;
             serverConnectorConfig.keyAlias = keyAlias;
             serverConnectorConfig.keyPassword = keyPassword;
+            serverConnectorConfig.sslProtocols = sslProtocols;
+            serverConnectorConfig.sslCiphers = sslCiphers;
 
             return serverConnectorConfig;
         }
@@ -146,6 +163,8 @@ public class ServerConnectorConfig {
     private String keystorePassword;
     private String keyAlias;
     private String keyPassword;
+    private List<String> sslProtocols;
+    private List<String> sslCiphers;
 
     public Integer getPort() {
         return port;
@@ -197,5 +216,13 @@ public class ServerConnectorConfig {
 
     public String getKeyPassword() {
         return keyPassword;
+    }
+
+    public List<String> getSslProtocols() {
+        return sslProtocols;
+    }
+
+    public List<String> getSslCiphers() {
+        return sslCiphers;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
@@ -1,3 +1,23 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+*/
 package com.kumuluz.ee.common.config;
 
 /**

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
@@ -34,6 +34,7 @@ public class ServerConnectorConfig {
         private Integer port;
         private String address;
         private Boolean enabled;
+        private Boolean proxyForwarding = false;
         private Integer requestHeaderSize = 8 * 1024;
         private Integer responseHeaderSize = 8 * 1024;
         private Integer idleTimeout = 60 * 60 * 1000;
@@ -56,6 +57,11 @@ public class ServerConnectorConfig {
 
         public Builder enabled(Boolean enabled) {
             this.enabled = enabled;
+            return this;
+        }
+
+        public Builder proxyForwarding(Boolean proxyForwarding) {
+            this.proxyForwarding = proxyForwarding;
             return this;
         }
 
@@ -105,6 +111,7 @@ public class ServerConnectorConfig {
             serverConnectorConfig.port = port;
             serverConnectorConfig.address = address;
             serverConnectorConfig.enabled = enabled;
+            serverConnectorConfig.proxyForwarding = proxyForwarding;
             serverConnectorConfig.requestHeaderSize = requestHeaderSize;
             serverConnectorConfig.responseHeaderSize = responseHeaderSize;
             serverConnectorConfig.idleTimeout = idleTimeout;
@@ -121,6 +128,7 @@ public class ServerConnectorConfig {
     private Integer port;
     private String address;
     private Boolean enabled;
+    private Boolean proxyForwarding;
     private Integer requestHeaderSize;
     private Integer responseHeaderSize;
     private Integer idleTimeout;
@@ -141,6 +149,10 @@ public class ServerConnectorConfig {
 
     public Boolean getEnabled() {
         return enabled;
+    }
+
+    public Boolean getProxyForwarding() {
+        return proxyForwarding;
     }
 
     public Integer getRequestHeaderSize() {

--- a/common/src/main/java/com/kumuluz/ee/common/config/XaDataSourceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/XaDataSourceConfig.java
@@ -29,43 +29,74 @@ import java.util.Map;
  */
 public class XaDataSourceConfig {
 
+    public static class Builder {
+
+        private String jndiName;
+        private String xaDatasourceClass;
+        private String username;
+        private String password;
+
+        private Map<String, String> props = new HashMap<>();
+
+        public Builder jndiName(String jndiName) {
+            this.jndiName = jndiName;
+            return this;
+        }
+
+        public Builder xaDatasourceClass(String xaDatasourceClass) {
+            this.xaDatasourceClass = xaDatasourceClass;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder prop(String key, String value) {
+            this.props.put(key, value);
+            return this;
+        }
+
+        public XaDataSourceConfig build() {
+
+            XaDataSourceConfig xaDataSourceConfig = new XaDataSourceConfig();
+            xaDataSourceConfig.jndiName = jndiName;
+            xaDataSourceConfig.xaDatasourceClass = xaDatasourceClass;
+            xaDataSourceConfig.username = username;
+            xaDataSourceConfig.password = password;
+            xaDataSourceConfig.props = props;
+
+            return xaDataSourceConfig;
+        }
+    }
+
     private String jndiName;
     private String xaDatasourceClass;
     private String username;
     private String password;
 
-    private Map<String, String> props = new HashMap<>();
+    private Map<String, String> props;
 
     public String getJndiName() {
         return jndiName;
-    }
-
-    public void setJndiName(String jndiName) {
-        this.jndiName = jndiName;
     }
 
     public String getXaDatasourceClass() {
         return xaDatasourceClass;
     }
 
-    public void setXaDatasourceClass(String xaDatasourceClass) {
-        this.xaDatasourceClass = xaDatasourceClass;
-    }
-
     public String getUsername() {
         return username;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
     public String getPassword() {
         return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
     }
 
     public Map<String, String> getProps() {

--- a/common/src/main/java/com/kumuluz/ee/common/utils/EnvUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/common/utils/EnvUtils.java
@@ -35,7 +35,7 @@ public class EnvUtils {
 
         Optional.ofNullable(System.getenv(var))
                 .filter(s -> !s.isEmpty())
-                .ifPresent(consumer::accept);
+                .ifPresent(consumer);
     }
 
     public static void getEnvAsInteger(String var, Consumer<Integer> consumer) {
@@ -47,16 +47,6 @@ public class EnvUtils {
                     .ifPresent(s -> consumer.accept(Integer.parseInt(s)));
         } catch (NumberFormatException e) {
 
-            throw new KumuluzServerException(var + "is in the incorrect format", e);
-        }
-    }
-
-    public static void getEnvAsBoolean(String var, Consumer<Boolean> consumer) {
-        try {
-            Optional.ofNullable(System.getenv(var))
-                    .filter(s -> !s.isEmpty())
-                    .ifPresent(s -> consumer.accept(Boolean.parseBoolean(s)));
-        } catch (NumberFormatException e) {
             throw new KumuluzServerException(var + "is in the incorrect format", e);
         }
     }

--- a/common/src/main/java/com/kumuluz/ee/common/utils/EnvUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/common/utils/EnvUtils.java
@@ -50,4 +50,14 @@ public class EnvUtils {
             throw new KumuluzServerException(var + "is in the incorrect format", e);
         }
     }
+
+    public static void getEnvAsBoolean(String var, Consumer<Boolean> consumer) {
+        try {
+            Optional.ofNullable(System.getenv(var))
+                    .filter(s -> !s.isEmpty())
+                    .ifPresent(s -> consumer.accept(Boolean.parseBoolean(s)));
+        } catch (NumberFormatException e) {
+            throw new KumuluzServerException(var + "is in the incorrect format", e);
+        }
+    }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/utils/StringUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/common/utils/StringUtils.java
@@ -20,7 +20,6 @@
 */
 package com.kumuluz.ee.common.utils;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -69,5 +68,9 @@ public class StringUtils {
         }
 
         return parsedString.toString();
+    }
+
+    public static boolean isNullOrEmpty(String s) {
+        return s == null || s.isEmpty();
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/utils/StringUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/common/utils/StringUtils.java
@@ -52,6 +52,12 @@ public class StringUtils {
         return parsedString.toString();
     }
 
+    /**
+     * Parse lower hyphen case to upper camel case.
+     *
+     * @param s string in lower hyphen case format
+     * @return string in upper camel case format
+     */
     public static String hyphenCaseToCamelCase(String s) {
 
         List<String> words = Stream.of(s.split("-")).filter(w -> !"".equals(w)).collect(Collectors.toList());
@@ -70,6 +76,12 @@ public class StringUtils {
         return parsedString.toString();
     }
 
+    /**
+     * Check whether the string is null or empty
+     *
+     * @param s string to check.
+     * @return 'true' if string is null or empty, 'false' otherwise.
+     */
     public static boolean isNullOrEmpty(String s) {
         return s == null || s.isEmpty();
     }

--- a/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationUtil.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationUtil.java
@@ -46,7 +46,7 @@ public class ConfigurationUtil {
     public static void initialize(ConfigurationImpl config) {
 
         if (instance != null) {
-            throw new IllegalStateException("");
+            throw new IllegalStateException("The ConfigurationUtil was already initialized.");
         }
 
         instance = new ConfigurationUtil(config);
@@ -55,7 +55,7 @@ public class ConfigurationUtil {
     public static ConfigurationUtil getInstance() {
 
         if (instance == null) {
-            throw new IllegalStateException("");
+            throw new IllegalStateException("The ConfigurationUtil was not yet initialized.");
         }
 
         return instance;

--- a/components/cdi/weld/src/main/java/com/kumuluz/ee/configuration/cdi/producers/EeConfigProducer.java
+++ b/components/cdi/weld/src/main/java/com/kumuluz/ee/configuration/cdi/producers/EeConfigProducer.java
@@ -1,0 +1,19 @@
+package com.kumuluz.ee.configuration.cdi.producers;
+
+import com.kumuluz.ee.common.config.EeConfig;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+/**
+ * @author Tilen Faganel
+ * @since 2.4.0
+ */
+public class EeConfigProducer {
+
+    @Produces
+    @ApplicationScoped
+    public EeConfig getConfigurationUtil() {
+        return EeConfig.getInstance();
+    }
+}

--- a/components/cdi/weld/src/main/java/com/kumuluz/ee/configuration/cdi/producers/EeConfigProducer.java
+++ b/components/cdi/weld/src/main/java/com/kumuluz/ee/configuration/cdi/producers/EeConfigProducer.java
@@ -1,3 +1,23 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+*/
 package com.kumuluz.ee.configuration.cdi.producers;
 
 import com.kumuluz.ee.common.config.EeConfig;

--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/PersistenceUnitHolder.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/PersistenceUnitHolder.java
@@ -35,7 +35,7 @@ import java.util.*;
 public class PersistenceUnitHolder {
 
     private PersistenceSettings providerProperties;
-    private List<PersistenceConfig> configs;
+    private PersistenceConfig config;
 
     private String defaultUnitName;
 
@@ -64,16 +64,12 @@ public class PersistenceUnitHolder {
                 properties.putAll(providerProperties.getPersistenceUnitProperties());
             }
 
-            Optional<PersistenceConfig> config = configs.stream()
-                    .filter(c -> unitName.equals(c.getUnitName()))
-                    .findFirst();
+            if (config != null && unitName.equals(config.getUnitName())) {
 
-            config.ifPresent(c -> {
-
-                Optional.ofNullable(c.getUrl()).ifPresent(u -> properties.put("javax.persistence.jdbc.url", u));
-                Optional.ofNullable(c.getUsername()).ifPresent(u -> properties.put("javax.persistence.jdbc.user", u));
-                Optional.ofNullable(c.getPassword()).ifPresent(p -> properties.put("javax.persistence.jdbc.password", p));
-            });
+                Optional.ofNullable(config.getUrl()).ifPresent(u -> properties.put("javax.persistence.jdbc.url", u));
+                Optional.ofNullable(config.getUsername()).ifPresent(u -> properties.put("javax.persistence.jdbc.user", u));
+                Optional.ofNullable(config.getPassword()).ifPresent(p -> properties.put("javax.persistence.jdbc.password", p));
+            }
 
             EntityManagerFactory factory = Persistence.createEntityManagerFactory(unitName, properties);
             TransactionType transactionType = PersistenceUtils.getEntityManagerFactoryTransactionType(factory);
@@ -90,8 +86,8 @@ public class PersistenceUnitHolder {
         return defaultUnitName;
     }
 
-    public void setConfigs(List<PersistenceConfig> configs) {
-        this.configs = configs;
+    public void setConfig(PersistenceConfig config) {
+        this.config = config;
     }
 
     public void setProviderProperties(PersistenceSettings providerProperties) {

--- a/components/jpa/eclipselink/src/main/java/com/kumuluz/ee/jpa/eclipselink/JpaComponent.java
+++ b/components/jpa/eclipselink/src/main/java/com/kumuluz/ee/jpa/eclipselink/JpaComponent.java
@@ -46,7 +46,7 @@ public class JpaComponent implements Component {
         // Check if JTA is present in the runtime
         Boolean jtaPresent = eeConfig.getEeComponents().stream().anyMatch(c -> c.getType().equals(EeComponentType.JTA));
 
-        holder.setConfigs(eeConfig.getPersistenceConfigs());
+        holder.setConfig(eeConfig.getPersistenceConfig());
         holder.setProviderProperties(new EclipseLinkSettings(jtaPresent));
     }
 

--- a/components/jpa/hibernate/src/main/java/com/kumuluz/ee/jpa/hibernate/JpaComponent.java
+++ b/components/jpa/hibernate/src/main/java/com/kumuluz/ee/jpa/hibernate/JpaComponent.java
@@ -41,7 +41,7 @@ public class JpaComponent implements Component {
     @Override
     public void init(KumuluzServerWrapper server, EeConfig eeConfig) {
 
-        PersistenceUnitHolder.getInstance().setConfigs(eeConfig.getPersistenceConfigs());
+        PersistenceUnitHolder.getInstance().setConfig(eeConfig.getPersistenceConfig());
     }
 
     @Override

--- a/core/src/main/java/com/kumuluz/ee/EeApplication.java
+++ b/core/src/main/java/com/kumuluz/ee/EeApplication.java
@@ -20,6 +20,7 @@
 */
 package com.kumuluz.ee;
 
+import com.kumuluz.ee.builders.EeConfigFactory;
 import com.kumuluz.ee.builders.JtaXADataSourceBuilder;
 import com.kumuluz.ee.common.*;
 import com.kumuluz.ee.common.config.DataSourceConfig;
@@ -92,8 +93,7 @@ public class EeApplication {
         ConfigurationUtil.initialize(configImpl);
 
         if (this.eeConfig == null) {
-            this.eeConfig = new EeConfig();
-            eeConfig.init();
+            this.eeConfig = EeConfigFactory.buildEeConfig();
         }
 
         log.info("Initialized main config");
@@ -136,7 +136,7 @@ public class EeApplication {
         log.info("Config extensions initialized");
 
         // Initiate the server
-        server.getServer().setServerConfig(eeConfig.getServerConfig());
+        server.getServer().setServerConfig(eeConfig.getServer());
         server.getServer().initServer();
 
         // Depending on the server type, initiate server specific functionality

--- a/core/src/main/java/com/kumuluz/ee/EeApplication.java
+++ b/core/src/main/java/com/kumuluz/ee/EeApplication.java
@@ -20,8 +20,8 @@
 */
 package com.kumuluz.ee;
 
-import com.kumuluz.ee.builders.EeConfigFactory;
-import com.kumuluz.ee.builders.JtaXADataSourceBuilder;
+import com.kumuluz.ee.factories.EeConfigFactory;
+import com.kumuluz.ee.factories.JtaXADataSourceFactory;
 import com.kumuluz.ee.common.*;
 import com.kumuluz.ee.common.config.DataSourceConfig;
 import com.kumuluz.ee.common.config.EeConfig;
@@ -181,7 +181,7 @@ public class EeApplication {
                     XADataSourceWrapper xaDataSourceWrapper;
 
                     if (jtaPresent) {
-                        xaDataSourceWrapper = JtaXADataSourceBuilder.buildJtaXADataSourceWrapper(xaDataSource);
+                        xaDataSourceWrapper = JtaXADataSourceFactory.buildJtaXADataSourceWrapper(xaDataSource);
                     } else {
                         xaDataSourceWrapper = new NonJtaXADataSourceWrapper(xaDataSource);
                     }

--- a/core/src/main/java/com/kumuluz/ee/EeApplication.java
+++ b/core/src/main/java/com/kumuluz/ee/EeApplication.java
@@ -94,6 +94,9 @@ public class EeApplication {
 
         if (this.eeConfig == null) {
             this.eeConfig = EeConfigFactory.buildEeConfig();
+        } else if (!EeConfigFactory.isEeConfigValid(this.eeConfig)) {
+            throw new KumuluzServerException("The programmatically supplied EeConfig is malformed." +
+                    "Please check the supplied values and the config reference to fix the missing or invalid values.");
         }
 
         EeConfig.initialize(this.eeConfig);

--- a/core/src/main/java/com/kumuluz/ee/EeApplication.java
+++ b/core/src/main/java/com/kumuluz/ee/EeApplication.java
@@ -96,7 +96,9 @@ public class EeApplication {
             this.eeConfig = EeConfigFactory.buildEeConfig();
         }
 
-        log.info("Initialized main config");
+        EeConfig.initialize(this.eeConfig);
+
+        log.info("Initialized main configuration");
 
         // Loading the kumuluz server and extracting its metadata
         KumuluzServer kumuluzServer = ServerLoader.loadServletServer();

--- a/core/src/main/java/com/kumuluz/ee/builders/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/builders/EeConfigFactory.java
@@ -1,0 +1,171 @@
+package com.kumuluz.ee.builders;
+
+import com.kumuluz.ee.common.config.*;
+import com.kumuluz.ee.common.utils.EnvUtils;
+import com.kumuluz.ee.common.utils.StringUtils;
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author Tilen Faganel
+ * @since 2.4.0
+ */
+public class EeConfigFactory {
+
+    private static final String PORT_ENV = "PORT";
+
+    private static final String LEGACY_MIN_THREADS_ENV = "MIN_THREADS";
+    private static final String LEGACY_MAX_THREADS_ENV = "MAX_THREADS";
+    private static final String LEGACY_REQUEST_HEADER_SIZE_ENV = "REQUEST_HEADER_SIZE";
+    private static final String LEGACY_RESPONSE_HEADER_SIZE_ENV = "RESPONSE_HEADER_SIZE";
+    private static final String LEGACY_CONTEXT_PATH_ENV = "CONTEXT_PATH";
+
+    public static EeConfig buildEeConfig() {
+
+        ConfigurationUtil cfg = ConfigurationUtil.getInstance();
+
+        EeConfig.Builder eeConfigBuilder = new EeConfig.Builder();
+
+        ServerConfig.Builder serverBuilder = new ServerConfig.Builder();
+
+        Optional<List<String>> serverCfgOpt = cfg.getMapKeys("kumuluzee.server");
+
+        EnvUtils.getEnv(LEGACY_CONTEXT_PATH_ENV, serverBuilder::contextPath);
+        EnvUtils.getEnvAsInteger(LEGACY_MIN_THREADS_ENV, serverBuilder::minThreads);
+        EnvUtils.getEnvAsInteger(LEGACY_MAX_THREADS_ENV, serverBuilder::maxThreads);
+
+        if (serverCfgOpt.isPresent()) {
+
+            Optional<String> contextPath = cfg.get("kumuluzee.server.context-path");
+            Optional<Integer> minThreads = cfg.getInteger("kumuluzee.server.min-threads");
+            Optional<Integer> maxThreads = cfg.getInteger("kumuluzee.server.max-threads");
+            Optional<Boolean> forceHttps = cfg.getBoolean("kumuluzee.server.force-https");
+
+            contextPath.ifPresent(serverBuilder::contextPath);
+            minThreads.ifPresent(serverBuilder::minThreads);
+            maxThreads.ifPresent(serverBuilder::maxThreads);
+            forceHttps.ifPresent(serverBuilder::forceHttps);
+
+            ServerConnectorConfig.Builder httpBuilder =
+                    createServerConnectorConfigBuilder("kumuluzee.server.http",
+                            ServerConnectorConfig.Builder.DEFAULT_HTTP_PORT);
+
+            EnvUtils.getEnvAsInteger(PORT_ENV, httpBuilder::port);
+
+            serverBuilder.http(httpBuilder);
+            serverBuilder.https(createServerConnectorConfigBuilder("kumuluzee.server.https",
+                    ServerConnectorConfig.Builder.DEFAULT_HTTPS_PORT));
+        }
+
+        eeConfigBuilder.server(serverBuilder);
+
+        Optional<Integer> dsSizeOpt = cfg.getListSize("kumuluzee.datasources");
+
+        if (dsSizeOpt.isPresent()) {
+
+            for (int i = 0; i < dsSizeOpt.get(); i++) {
+
+                DataSourceConfig.Builder dsc = new DataSourceConfig.Builder();
+
+                Optional<String> jndiName = cfg.get("kumuluzee.datasources[" + i + "].jndi-name");
+                Optional<String> driverClass = cfg.get("kumuluzee.datasources[" + i + "].driver-class");
+                Optional<String> conUrl = cfg.get("kumuluzee.datasources[" + i + "].connection-url");
+                Optional<String> user = cfg.get("kumuluzee.datasources[" + i + "].username");
+                Optional<String> pass = cfg.get("kumuluzee.datasources[" + i + "].password");
+                Optional<Integer> maxPool = cfg.getInteger("kumuluzee.datasources[" + i + "].max-pool-size");
+
+                jndiName.ifPresent(dsc::jndiName);
+                driverClass.ifPresent(dsc::driverClass);
+                conUrl.ifPresent(dsc::connectionUrl);
+                user.ifPresent(dsc::username);
+                pass.ifPresent(dsc::password);
+                maxPool.ifPresent(dsc::maxPoolSize);
+
+                eeConfigBuilder.datasource(dsc);
+            }
+        }
+
+        Optional<Integer> xDsSizeOpt = cfg.getListSize("kumuluzee.xa-datasources");
+
+        if (xDsSizeOpt.isPresent()) {
+
+            for (int i = 0; i < xDsSizeOpt.get(); i++) {
+
+                XaDataSourceConfig.Builder xdsc = new XaDataSourceConfig.Builder();
+
+                Optional<String> jndiName = cfg.get("kumuluzee.xa-datasources[" + i + "].jndi-name");
+                Optional<String> xaDatasourceClass = cfg.get("kumuluzee.xa-datasources[" + i + "].xa-datasource-class");
+                Optional<String> user = cfg.get("kumuluzee.xa-datasources[" + i + "].username");
+                Optional<String> pass = cfg.get("kumuluzee.xa-datasources[" + i + "].password");
+
+                jndiName.ifPresent(xdsc::jndiName);
+                xaDatasourceClass.ifPresent(xdsc::xaDatasourceClass);
+                user.ifPresent(xdsc::username);
+                pass.ifPresent(xdsc::password);
+
+                Optional<List<String>> props = cfg.getMapKeys("kumuluzee.xa-datasources[" + i + "].props");
+
+                if (props.isPresent()) {
+
+                    for (String propName : props.get()) {
+
+                        Optional<String> propValue = cfg.get("kumuluzee.xa-datasources[" + i + "].props." + propName);
+
+                        propValue.ifPresent(v -> xdsc.prop(StringUtils.hyphenCaseToCamelCase(propName), v));
+                    }
+                }
+
+                eeConfigBuilder.xaDatasource(xdsc);
+            }
+        }
+
+        return eeConfigBuilder.build();
+    }
+
+    private static ServerConnectorConfig.Builder createServerConnectorConfigBuilder(String prefix, Integer defaultPort) {
+
+        ConfigurationUtil cfg = ConfigurationUtil.getInstance();
+
+        ServerConnectorConfig.Builder serverConnectorConfigBuilder = new ServerConnectorConfig.Builder();
+
+        serverConnectorConfigBuilder.port(defaultPort);
+
+        EnvUtils.getEnvAsInteger(LEGACY_REQUEST_HEADER_SIZE_ENV, serverConnectorConfigBuilder::requestHeaderSize);
+        EnvUtils.getEnvAsInteger(LEGACY_RESPONSE_HEADER_SIZE_ENV, serverConnectorConfigBuilder::responseHeaderSize);
+
+        Optional<List<String>> serverConnectorCfgOpt = cfg.getMapKeys(prefix);
+
+        if (serverConnectorCfgOpt.isPresent()) {
+
+            Optional<Integer> port = cfg.getInteger(prefix + ".port");
+            Optional<String> address = cfg.get(prefix + ".address");
+            Optional<Boolean> enabled = cfg.getBoolean(prefix + ".enabled");
+            Optional<Integer> requestHeaderSize = cfg.getInteger(prefix + ".request-header-size");
+            Optional<Integer> responseHeaderSize = cfg.getInteger(prefix + ".kresponse-header-size");
+            Optional<Integer> idleTimeout = cfg.getInteger(prefix + ".idle-timeout");
+            Optional<Integer> soLingerTime = cfg.getInteger(prefix + ".so-linger-time");
+
+            Optional<String> keystorePath = cfg.get(prefix + ".keystore-path");
+            Optional<String> keystorePassword = cfg.get(prefix + ".keystore-password");
+            Optional<String> keyAlias = cfg.get(prefix + ".key-alias");
+            Optional<String> keyPassword = cfg.get(prefix + ".key-password");
+
+            port.ifPresent(serverConnectorConfigBuilder::port);
+            address.ifPresent(serverConnectorConfigBuilder::address);
+            enabled.ifPresent(serverConnectorConfigBuilder::enabled);
+            requestHeaderSize.ifPresent(serverConnectorConfigBuilder::requestHeaderSize);
+            responseHeaderSize.ifPresent(serverConnectorConfigBuilder::responseHeaderSize);
+            idleTimeout.ifPresent(serverConnectorConfigBuilder::idleTimeout);
+            soLingerTime.ifPresent(serverConnectorConfigBuilder::soLingerTime);
+
+            keystorePath.ifPresent(serverConnectorConfigBuilder::keystorePath);
+            keystorePassword.ifPresent(serverConnectorConfigBuilder::keystorePassword);
+            keyAlias.ifPresent(serverConnectorConfigBuilder::keyAlias);
+            keyPassword.ifPresent(serverConnectorConfigBuilder::keyPassword);
+        }
+
+        return serverConnectorConfigBuilder;
+    }
+}

--- a/core/src/main/java/com/kumuluz/ee/builders/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/builders/EeConfigFactory.java
@@ -22,6 +22,11 @@ public class EeConfigFactory {
     private static final String LEGACY_RESPONSE_HEADER_SIZE_ENV = "RESPONSE_HEADER_SIZE";
     private static final String LEGACY_CONTEXT_PATH_ENV = "CONTEXT_PATH";
 
+    private static final String LEGACY_DB_UNIT_ENV = "DATABASE_UNIT";
+    private static final String LEGACY_DB_URL_ENV = "DATABASE_URL";
+    private static final String LEGACY_DB_USER_ENV = "DATABASE_USER";
+    private static final String LEGACY_DB_PASS_ENV = "DATABASE_PASS";
+
     public static EeConfig buildEeConfig() {
 
         ConfigurationUtil cfg = ConfigurationUtil.getInstance();
@@ -121,6 +126,15 @@ public class EeConfigFactory {
             }
         }
 
+        PersistenceConfig.Builder persistenceBuilder = new PersistenceConfig.Builder();
+
+        EnvUtils.getEnv(LEGACY_DB_UNIT_ENV, persistenceBuilder::unitName);
+        EnvUtils.getEnv(LEGACY_DB_URL_ENV, persistenceBuilder::url);
+        EnvUtils.getEnv(LEGACY_DB_USER_ENV, persistenceBuilder::username);
+        EnvUtils.getEnv(LEGACY_DB_PASS_ENV, persistenceBuilder::password);
+
+        eeConfigBuilder.persistenceConfig(persistenceBuilder);
+
         return eeConfigBuilder.build();
     }
 
@@ -128,12 +142,12 @@ public class EeConfigFactory {
 
         ConfigurationUtil cfg = ConfigurationUtil.getInstance();
 
-        ServerConnectorConfig.Builder serverConnectorConfigBuilder = new ServerConnectorConfig.Builder();
+        ServerConnectorConfig.Builder serverConnectorBuilder = new ServerConnectorConfig.Builder();
 
-        serverConnectorConfigBuilder.port(defaultPort);
+        serverConnectorBuilder.port(defaultPort);
 
-        EnvUtils.getEnvAsInteger(LEGACY_REQUEST_HEADER_SIZE_ENV, serverConnectorConfigBuilder::requestHeaderSize);
-        EnvUtils.getEnvAsInteger(LEGACY_RESPONSE_HEADER_SIZE_ENV, serverConnectorConfigBuilder::responseHeaderSize);
+        EnvUtils.getEnvAsInteger(LEGACY_REQUEST_HEADER_SIZE_ENV, serverConnectorBuilder::requestHeaderSize);
+        EnvUtils.getEnvAsInteger(LEGACY_RESPONSE_HEADER_SIZE_ENV, serverConnectorBuilder::responseHeaderSize);
 
         Optional<List<String>> serverConnectorCfgOpt = cfg.getMapKeys(prefix);
 
@@ -152,20 +166,20 @@ public class EeConfigFactory {
             Optional<String> keyAlias = cfg.get(prefix + ".key-alias");
             Optional<String> keyPassword = cfg.get(prefix + ".key-password");
 
-            port.ifPresent(serverConnectorConfigBuilder::port);
-            address.ifPresent(serverConnectorConfigBuilder::address);
-            enabled.ifPresent(serverConnectorConfigBuilder::enabled);
-            requestHeaderSize.ifPresent(serverConnectorConfigBuilder::requestHeaderSize);
-            responseHeaderSize.ifPresent(serverConnectorConfigBuilder::responseHeaderSize);
-            idleTimeout.ifPresent(serverConnectorConfigBuilder::idleTimeout);
-            soLingerTime.ifPresent(serverConnectorConfigBuilder::soLingerTime);
+            port.ifPresent(serverConnectorBuilder::port);
+            address.ifPresent(serverConnectorBuilder::address);
+            enabled.ifPresent(serverConnectorBuilder::enabled);
+            requestHeaderSize.ifPresent(serverConnectorBuilder::requestHeaderSize);
+            responseHeaderSize.ifPresent(serverConnectorBuilder::responseHeaderSize);
+            idleTimeout.ifPresent(serverConnectorBuilder::idleTimeout);
+            soLingerTime.ifPresent(serverConnectorBuilder::soLingerTime);
 
-            keystorePath.ifPresent(serverConnectorConfigBuilder::keystorePath);
-            keystorePassword.ifPresent(serverConnectorConfigBuilder::keystorePassword);
-            keyAlias.ifPresent(serverConnectorConfigBuilder::keyAlias);
-            keyPassword.ifPresent(serverConnectorConfigBuilder::keyPassword);
+            keystorePath.ifPresent(serverConnectorBuilder::keystorePath);
+            keystorePassword.ifPresent(serverConnectorBuilder::keystorePassword);
+            keyAlias.ifPresent(serverConnectorBuilder::keyAlias);
+            keyPassword.ifPresent(serverConnectorBuilder::keyPassword);
         }
 
-        return serverConnectorConfigBuilder;
+        return serverConnectorBuilder;
     }
 }

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -176,6 +176,7 @@ public class EeConfigFactory {
             Optional<Integer> port = cfg.getInteger(prefix + ".port");
             Optional<String> address = cfg.get(prefix + ".address");
             Optional<Boolean> enabled = cfg.getBoolean(prefix + ".enabled");
+            Optional<Boolean> proxyForwarding = cfg.getBoolean(prefix + ".proxy-forwarding");
             Optional<Integer> requestHeaderSize = cfg.getInteger(prefix + ".request-header-size");
             Optional<Integer> responseHeaderSize = cfg.getInteger(prefix + ".kresponse-header-size");
             Optional<Integer> idleTimeout = cfg.getInteger(prefix + ".idle-timeout");
@@ -189,6 +190,7 @@ public class EeConfigFactory {
             port.ifPresent(serverConnectorBuilder::port);
             address.ifPresent(serverConnectorBuilder::address);
             enabled.ifPresent(serverConnectorBuilder::enabled);
+            proxyForwarding.ifPresent(serverConnectorBuilder::proxyForwarding);
             requestHeaderSize.ifPresent(serverConnectorBuilder::requestHeaderSize);
             responseHeaderSize.ifPresent(serverConnectorBuilder::responseHeaderSize);
             idleTimeout.ifPresent(serverConnectorBuilder::idleTimeout);

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -170,12 +170,14 @@ public class EeConfigFactory {
                 eeConfig.getServer().getHttp() == null ||
                 eeConfig.getServer().getHttps() == null ||
                 eeConfig.getServer().getHttp().getPort() == null ||
+                eeConfig.getServer().getHttp().getHttp2() == null ||
                 eeConfig.getServer().getHttp().getProxyForwarding() == null ||
                 eeConfig.getServer().getHttp().getRequestHeaderSize() == null ||
                 eeConfig.getServer().getHttp().getResponseHeaderSize() == null ||
                 eeConfig.getServer().getHttp().getIdleTimeout() == null ||
                 eeConfig.getServer().getHttp().getSoLingerTime() == null ||
                 eeConfig.getServer().getHttps().getPort() == null ||
+                eeConfig.getServer().getHttps().getHttp2() == null ||
                 eeConfig.getServer().getHttps().getProxyForwarding() == null ||
                 eeConfig.getServer().getHttps().getRequestHeaderSize() == null ||
                 eeConfig.getServer().getHttps().getResponseHeaderSize() == null ||
@@ -203,6 +205,7 @@ public class EeConfigFactory {
             Optional<Integer> port = cfg.getInteger(prefix + ".port");
             Optional<String> address = cfg.get(prefix + ".address");
             Optional<Boolean> enabled = cfg.getBoolean(prefix + ".enabled");
+            Optional<Boolean> http2 = cfg.getBoolean(prefix + ".http2");
             Optional<Boolean> proxyForwarding = cfg.getBoolean(prefix + ".proxy-forwarding");
             Optional<Integer> requestHeaderSize = cfg.getInteger(prefix + ".request-header-size");
             Optional<Integer> responseHeaderSize = cfg.getInteger(prefix + ".kresponse-header-size");
@@ -217,6 +220,7 @@ public class EeConfigFactory {
             port.ifPresent(serverConnectorBuilder::port);
             address.ifPresent(serverConnectorBuilder::address);
             enabled.ifPresent(serverConnectorBuilder::enabled);
+            http2.ifPresent(serverConnectorBuilder::http2);
             proxyForwarding.ifPresent(serverConnectorBuilder::proxyForwarding);
             requestHeaderSize.ifPresent(serverConnectorBuilder::requestHeaderSize);
             responseHeaderSize.ifPresent(serverConnectorBuilder::responseHeaderSize);

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -21,6 +21,7 @@
 package com.kumuluz.ee.factories;
 
 import com.kumuluz.ee.common.config.*;
+import com.kumuluz.ee.common.exceptions.KumuluzServerException;
 import com.kumuluz.ee.common.utils.EnvUtils;
 import com.kumuluz.ee.common.utils.StringUtils;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
@@ -156,6 +157,32 @@ public class EeConfigFactory {
         eeConfigBuilder.persistenceConfig(persistenceBuilder);
 
         return eeConfigBuilder.build();
+    }
+
+    public static Boolean isEeConfigValid(EeConfig eeConfig) {
+
+        return !(eeConfig == null ||
+                eeConfig.getServer() == null ||
+                eeConfig.getServer().getContextPath() == null ||
+                eeConfig.getServer().getForceHttps() == null ||
+                eeConfig.getServer().getMinThreads() == null ||
+                eeConfig.getServer().getMaxThreads() == null ||
+                eeConfig.getServer().getHttp() == null ||
+                eeConfig.getServer().getHttps() == null ||
+                eeConfig.getServer().getHttp().getPort() == null ||
+                eeConfig.getServer().getHttp().getProxyForwarding() == null ||
+                eeConfig.getServer().getHttp().getRequestHeaderSize() == null ||
+                eeConfig.getServer().getHttp().getResponseHeaderSize() == null ||
+                eeConfig.getServer().getHttp().getIdleTimeout() == null ||
+                eeConfig.getServer().getHttp().getSoLingerTime() == null ||
+                eeConfig.getServer().getHttps().getPort() == null ||
+                eeConfig.getServer().getHttps().getProxyForwarding() == null ||
+                eeConfig.getServer().getHttps().getRequestHeaderSize() == null ||
+                eeConfig.getServer().getHttps().getResponseHeaderSize() == null ||
+                eeConfig.getServer().getHttps().getIdleTimeout() == null ||
+                eeConfig.getServer().getHttps().getSoLingerTime() == null ||
+                eeConfig.getServer().getHttps().getKeystorePath() == null ||
+                eeConfig.getServer().getHttps().getKeystorePassword() == null);
     }
 
     private static ServerConnectorConfig.Builder createServerConnectorConfigBuilder(String prefix, Integer defaultPort) {

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -1,4 +1,24 @@
-package com.kumuluz.ee.builders;
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+*/
+package com.kumuluz.ee.factories;
 
 import com.kumuluz.ee.common.config.*;
 import com.kumuluz.ee.common.utils.EnvUtils;

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -26,8 +26,11 @@ import com.kumuluz.ee.common.utils.EnvUtils;
 import com.kumuluz.ee.common.utils.StringUtils;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Tilen Faganel
@@ -216,6 +219,8 @@ public class EeConfigFactory {
             Optional<String> keystorePassword = cfg.get(prefix + ".keystore-password");
             Optional<String> keyAlias = cfg.get(prefix + ".key-alias");
             Optional<String> keyPassword = cfg.get(prefix + ".key-password");
+            Optional<String> sslProtocols = cfg.get(prefix + ".ssl-protocols");
+            Optional<String> sslCiphers = cfg.get(prefix + ".ssl-ciphers");
 
             port.ifPresent(serverConnectorBuilder::port);
             address.ifPresent(serverConnectorBuilder::address);
@@ -231,6 +236,8 @@ public class EeConfigFactory {
             keystorePassword.ifPresent(serverConnectorBuilder::keystorePassword);
             keyAlias.ifPresent(serverConnectorBuilder::keyAlias);
             keyPassword.ifPresent(serverConnectorBuilder::keyPassword);
+            sslProtocols.ifPresent(p -> serverConnectorBuilder.sslProtocols(Stream.of(p.split(",")).map(String::trim).collect(Collectors.toList())));
+            sslCiphers.ifPresent(c -> serverConnectorBuilder.sslCiphers(Stream.of(c.split(",")).map(String::trim).collect(Collectors.toList())));
         }
 
         return serverConnectorBuilder;

--- a/core/src/main/java/com/kumuluz/ee/factories/JtaXADataSourceFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/JtaXADataSourceFactory.java
@@ -18,7 +18,7 @@
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
 */
-package com.kumuluz.ee.builders;
+package com.kumuluz.ee.factories;
 
 import com.kumuluz.ee.common.datasources.NonJtaXADataSourceWrapper;
 import com.kumuluz.ee.jta.common.datasources.JtaXADataSourceWrapper;
@@ -29,7 +29,7 @@ import javax.sql.XADataSource;
  * @author Tilen Faganel
  * @since 2.3.0
  */
-public class JtaXADataSourceBuilder {
+public class JtaXADataSourceFactory {
 
     public static NonJtaXADataSourceWrapper buildJtaXADataSourceWrapper(XADataSource xaDataSource) {
 

--- a/servlet/jetty/pom.xml
+++ b/servlet/jetty/pom.xml
@@ -39,6 +39,21 @@
             <artifactId>jetty-jndi</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-http-client-transport</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
@@ -173,6 +173,17 @@ public class JettyFactory {
                 sslContextFactory.setCertAlias(httpsConfig.getKeyAlias());
             }
 
+            if (httpsConfig.getSslProtocols() != null) {
+
+                sslContextFactory.setIncludeProtocols(httpsConfig.getSslProtocols().toArray(new String[0]));
+            }
+
+            if (httpsConfig.getSslCiphers() != null) {
+
+                sslContextFactory.setExcludeCipherSuites();
+                sslContextFactory.setIncludeCipherSuites(httpsConfig.getSslCiphers().toArray(new String[0]));
+            }
+
             if (httpsConfig.getHttp2()) {
 
                 sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
@@ -88,11 +88,23 @@ public class JettyFactory {
 
         List<ServerConnector> connectors = new ArrayList<>();
 
+        if (Boolean.FALSE.equals(httpConfig.getEnabled()) && Boolean.FALSE.equals(httpsConfig.getEnabled())) {
+            throw new IllegalStateException("Both the HTTP and HTTPS connectors can not be disabled. Please enable at least one.");
+        }
+
+        if (serverConfig.getForceHttps() && !Boolean.TRUE.equals(httpsConfig.getEnabled())) {
+            throw new IllegalStateException("You must enable the HTTPS connector in order to force redirects to it (`kumuluzee.server.https.enabled` must be true).");
+        }
+
         if (httpConfig.getEnabled() == null || httpConfig.getEnabled()) {
 
             HttpConfiguration httpConfiguration = new HttpConfiguration();
             httpConfiguration.setRequestHeaderSize(httpConfig.getRequestHeaderSize());
             httpConfiguration.setResponseHeaderSize(httpConfig.getResponseHeaderSize());
+
+            if (Boolean.TRUE.equals(httpsConfig.getEnabled())) {
+                httpConfiguration.setSecurePort(httpsConfig.getPort());
+            }
 
             ServerConnector httpConnector = new ServerConnector(server, new HttpConnectionFactory(httpConfiguration));
 

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
@@ -102,6 +102,10 @@ public class JettyFactory {
             httpConfiguration.setRequestHeaderSize(httpConfig.getRequestHeaderSize());
             httpConfiguration.setResponseHeaderSize(httpConfig.getResponseHeaderSize());
 
+            if (Boolean.TRUE.equals(httpConfig.getProxyForwarding())) {
+                httpConfiguration.addCustomizer(new ForwardedRequestCustomizer());
+            }
+
             if (Boolean.TRUE.equals(httpsConfig.getEnabled())) {
                 httpConfiguration.setSecurePort(httpsConfig.getPort());
             }
@@ -135,6 +139,10 @@ public class JettyFactory {
             httpsConfiguration.setRequestHeaderSize(httpsConfig.getRequestHeaderSize());
             httpsConfiguration.setResponseHeaderSize(httpsConfig.getResponseHeaderSize());
             httpsConfiguration.addCustomizer(new SecureRequestCustomizer());
+
+            if (Boolean.TRUE.equals(httpsConfig.getProxyForwarding())) {
+                httpsConfiguration.addCustomizer(new ForwardedRequestCustomizer());
+            }
 
             SslContextFactory sslContextFactory = new SslContextFactory();
             sslContextFactory.setKeyStorePath(httpsConfig.getKeystorePath());

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -29,7 +29,10 @@ import com.kumuluz.ee.common.exceptions.KumuluzServerException;
 import com.kumuluz.ee.common.utils.ResourceUtils;
 
 import org.eclipse.jetty.plus.jndi.Resource;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.SecuredRedirectHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -124,7 +127,18 @@ public class JettyServletServer implements ServletServer {
 
         log.info("Starting KumuluzEE with context root '" + serverConfig.getContextPath() + "'");
 
-        server.setHandler(appContext);
+        // Set the secured redirect handler in case the force https option is selected
+        if (serverConfig.getForceHttps()) {
+
+            HandlerList handlers = new HandlerList();
+            handlers.setHandlers(new Handler[]
+                    { new SecuredRedirectHandler(), appContext});
+
+            server.setHandler(handlers);
+        } else {
+
+            server.setHandler(appContext);
+        }
     }
 
     @Override


### PR DESCRIPTION
Added SSL support for KumuluzEE. This resolves #33.

To enable SSL, users have to set the `ENABLE_SSL=true` environment property and specify the keystore path and password using the `KEYSTORE_PATH` and `KEYSTORE_PASSWORD` environment variables. 

The default HTTPS port is set to 8443.

Users can force SSL by using the `FORCE_SSL=true` variable.