### PR TITLE
Added support for advanced DataSource and connection pool configuration options

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/DataSourceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/DataSourceConfig.java
@@ -20,6 +20,10 @@
 */
 package com.kumuluz.ee.common.config;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @author Tilen Faganel
  * @since 2.1.0
@@ -30,10 +34,16 @@ public class DataSourceConfig {
 
         private String jndiName;
         private String driverClass;
+        private String dataSourceClass;
         private String connectionUrl;
         private String username;
         private String password;
 
+        private DataSourcePoolConfig.Builder pool = new DataSourcePoolConfig.Builder();
+
+        private Map<String, String> props = new HashMap<>();
+
+        @Deprecated
         private Integer maxPoolSize;
 
         public Builder jndiName(String jndiName) {
@@ -43,6 +53,11 @@ public class DataSourceConfig {
 
         public Builder driverClass(String driverClass) {
             this.driverClass = driverClass;
+            return this;
+        }
+
+        public Builder dataSourceClass(String dataSourceClass) {
+            this.dataSourceClass = dataSourceClass;
             return this;
         }
 
@@ -61,6 +76,17 @@ public class DataSourceConfig {
             return this;
         }
 
+        public Builder pool(DataSourcePoolConfig.Builder pool) {
+            this.pool = pool;
+            return this;
+        }
+
+        public Builder prop(String key, String value) {
+            this.props.put(key, value);
+            return this;
+        }
+
+        @Deprecated
         public Builder maxPoolSize(Integer maxPoolSize) {
             this.maxPoolSize = maxPoolSize;
             return this;
@@ -71,9 +97,15 @@ public class DataSourceConfig {
             DataSourceConfig dataSourceConfig = new DataSourceConfig();
             dataSourceConfig.jndiName = jndiName;
             dataSourceConfig.driverClass = driverClass;
+            dataSourceConfig.dataSourceClass = dataSourceClass;
             dataSourceConfig.connectionUrl = connectionUrl;
             dataSourceConfig.username = username;
             dataSourceConfig.password = password;
+
+            dataSourceConfig.pool = pool.build();
+
+            dataSourceConfig.props = Collections.unmodifiableMap(props);
+
             dataSourceConfig.maxPoolSize = maxPoolSize;
 
             return dataSourceConfig;
@@ -82,11 +114,20 @@ public class DataSourceConfig {
 
     private String jndiName;
     private String driverClass;
+    private String dataSourceClass;
     private String connectionUrl;
     private String username;
     private String password;
 
+    private DataSourcePoolConfig pool;
+
+    private Map<String, String> props;
+
+    @Deprecated
     private Integer maxPoolSize;
+
+    private DataSourceConfig() {
+    }
 
     public String getJndiName() {
         return jndiName;
@@ -94,6 +135,10 @@ public class DataSourceConfig {
 
     public String getDriverClass() {
         return driverClass;
+    }
+
+    public String getDataSourceClass() {
+        return dataSourceClass;
     }
 
     public String getConnectionUrl() {
@@ -108,6 +153,15 @@ public class DataSourceConfig {
         return password;
     }
 
+    public DataSourcePoolConfig getPool() {
+        return pool;
+    }
+
+    public Map<String, String> getProps() {
+        return props;
+    }
+
+    @Deprecated
     public Integer getMaxPoolSize() {
         return maxPoolSize;
     }

--- a/common/src/main/java/com/kumuluz/ee/common/config/DataSourcePoolConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/DataSourcePoolConfig.java
@@ -1,0 +1,211 @@
+package com.kumuluz.ee.common.config;
+
+public class DataSourcePoolConfig {
+
+    public static class Builder {
+
+        private Boolean autoCommit = true;
+        private Long connectionTimeout = 30000L;
+        private Long idleTimeout = 600000L;
+        private Long maxLifetime = 1800000L;
+        private Integer minIdle;
+        private Integer maxSize = 10;
+        private String name;
+        private Long initializationFailTimeout = 1L;
+        private Boolean isolateInternalQueries = false;
+        private Boolean allowPoolSuspension = false;
+        private Boolean readOnly = false;
+        private Boolean registerMbeans = false;
+        private String connectionInitSql;
+        private String transactionIsolation;
+        private Long validationTimeout = 5000L;
+        private Long leakDetectionThreshold = 0L;
+
+        public Builder autoCommit(Boolean autoCommit) {
+            this.autoCommit = autoCommit;
+            return this;
+        }
+
+        public Builder connectionTimeout(Long connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public Builder idleTimeout(Long idleTimeout) {
+            this.idleTimeout = idleTimeout;
+            return this;
+        }
+
+        public Builder maxLifetime(Long maxLifetime) {
+            this.maxLifetime = maxLifetime;
+            return this;
+        }
+
+        public Builder minIdle(Integer minIdle) {
+            this.minIdle = minIdle;
+            return this;
+        }
+
+        public Builder maxSize(Integer maxSize) {
+            this.maxSize = maxSize;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder initializationFailTimeout(Long initializationFailTimeout) {
+            this.initializationFailTimeout = initializationFailTimeout;
+            return this;
+        }
+
+        public Builder isolateInternalQueries(Boolean isolateInternalQueries) {
+            this.isolateInternalQueries = isolateInternalQueries;
+            return this;
+        }
+
+        public Builder allowPoolSuspension(Boolean allowPoolSuspension) {
+            this.allowPoolSuspension = allowPoolSuspension;
+            return this;
+        }
+
+        public Builder readOnly(Boolean readOnly) {
+            this.readOnly = readOnly;
+            return this;
+        }
+
+        public Builder registerMbeans(Boolean registerMbeans) {
+            this.registerMbeans = registerMbeans;
+            return this;
+        }
+
+        public Builder connectionInitSql(String connectionInitSql) {
+            this.connectionInitSql = connectionInitSql;
+            return this;
+        }
+
+        public Builder transactionIsolation(String transactionIsolation) {
+            this.transactionIsolation = transactionIsolation;
+            return this;
+        }
+
+        public Builder validationTimeout(Long validationTimeout) {
+            this.validationTimeout = validationTimeout;
+            return this;
+        }
+
+        public Builder leakDetectionThreshold(Long leakDetectionThreshold) {
+            this.leakDetectionThreshold = leakDetectionThreshold;
+            return this;
+        }
+
+        public DataSourcePoolConfig build() {
+
+            DataSourcePoolConfig dataSourcePoolConfig = new DataSourcePoolConfig();
+            dataSourcePoolConfig.autoCommit = autoCommit;
+            dataSourcePoolConfig.connectionTimeout = connectionTimeout;
+            dataSourcePoolConfig.idleTimeout = idleTimeout;
+            dataSourcePoolConfig.maxLifetime = maxLifetime;
+            dataSourcePoolConfig.minIdle = minIdle;
+            dataSourcePoolConfig.maxSize = maxSize;
+            dataSourcePoolConfig.name = name;
+            dataSourcePoolConfig.initializationFailTimeout = initializationFailTimeout;
+            dataSourcePoolConfig.isolateInternalQueries = isolateInternalQueries;
+            dataSourcePoolConfig.allowPoolSuspension = allowPoolSuspension;
+            dataSourcePoolConfig.readOnly = readOnly;
+            dataSourcePoolConfig.registerMbeans = registerMbeans;
+            dataSourcePoolConfig.connectionInitSql = connectionInitSql;
+            dataSourcePoolConfig.transactionIsolation = transactionIsolation;
+            dataSourcePoolConfig.validationTimeout = validationTimeout;
+            dataSourcePoolConfig.leakDetectionThreshold = leakDetectionThreshold;
+
+            return dataSourcePoolConfig;
+        }
+    }
+
+    private Boolean autoCommit;
+    private Long connectionTimeout;
+    private Long idleTimeout;
+    private Long maxLifetime;
+    private Integer minIdle;
+    private Integer maxSize;
+    private String name;
+    private Long initializationFailTimeout;
+    private Boolean isolateInternalQueries;
+    private Boolean allowPoolSuspension;
+    private Boolean readOnly;
+    private Boolean registerMbeans;
+    private String connectionInitSql;
+    private String transactionIsolation;
+    private Long validationTimeout;
+    private Long leakDetectionThreshold;
+
+    private DataSourcePoolConfig() {
+    }
+
+    public Boolean getAutoCommit() {
+        return autoCommit;
+    }
+
+    public Long getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public Long getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    public Long getMaxLifetime() {
+        return maxLifetime;
+    }
+
+    public Integer getMinIdle() {
+        return minIdle;
+    }
+
+    public Integer getMaxSize() {
+        return maxSize;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getInitializationFailTimeout() {
+        return initializationFailTimeout;
+    }
+
+    public Boolean getIsolateInternalQueries() {
+        return isolateInternalQueries;
+    }
+
+    public Boolean getAllowPoolSuspension() {
+        return allowPoolSuspension;
+    }
+
+    public Boolean getReadOnly() {
+        return readOnly;
+    }
+
+    public Boolean getRegisterMbeans() {
+        return registerMbeans;
+    }
+
+    public String getConnectionInitSql() {
+        return connectionInitSql;
+    }
+
+    public String getTransactionIsolation() {
+        return transactionIsolation;
+    }
+
+    public Long getValidationTimeout() {
+        return validationTimeout;
+    }
+
+    public Long getLeakDetectionThreshold() {
+        return leakDetectionThreshold;
+    }
+}

--- a/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/EeConfig.java
@@ -80,13 +80,13 @@ public class EeConfig {
 
     private static EeConfig instance;
 
-    private ServerConfig server = new ServerConfig();
-    private List<DataSourceConfig> datasources = new ArrayList<>();
-    private List<XaDataSourceConfig> xaDatasources = new ArrayList<>();
+    private ServerConfig server;
+    private List<DataSourceConfig> datasources;
+    private List<XaDataSourceConfig> xaDatasources;
 
     private PersistenceConfig persistenceConfig;
 
-    protected EeConfig() {
+    private EeConfig() {
     }
 
     public static void initialize(EeConfig eeConfig) {

--- a/common/src/main/java/com/kumuluz/ee/common/config/PersistenceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/PersistenceConfig.java
@@ -73,6 +73,9 @@ public class PersistenceConfig {
     private String username;
     private String password;
 
+    private PersistenceConfig() {
+    }
+
     public String getUnitName() {
         return unitName;
     }

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -89,6 +89,9 @@ public class ServerConfig {
     private ServerConnectorConfig http;
     private ServerConnectorConfig https;
 
+    private ServerConfig() {
+    }
+
     public String getContextPath() {
         return contextPath;
     }

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
@@ -166,6 +166,9 @@ public class ServerConnectorConfig {
     private List<String> sslProtocols;
     private List<String> sslCiphers;
 
+    private ServerConnectorConfig() {
+    }
+
     public Integer getPort() {
         return port;
     }

--- a/core/src/main/java/com/kumuluz/ee/EeApplication.java
+++ b/core/src/main/java/com/kumuluz/ee/EeApplication.java
@@ -20,9 +20,11 @@
 */
 package com.kumuluz.ee;
 
+import com.kumuluz.ee.common.config.DataSourcePoolConfig;
 import com.kumuluz.ee.common.runtime.EeRuntime;
 import com.kumuluz.ee.common.runtime.EeRuntimeComponent;
 import com.kumuluz.ee.common.runtime.EeRuntimeInternal;
+import com.kumuluz.ee.common.utils.StringUtils;
 import com.kumuluz.ee.factories.EeConfigFactory;
 import com.kumuluz.ee.factories.JtaXADataSourceFactory;
 import com.kumuluz.ee.common.*;
@@ -44,6 +46,7 @@ import com.kumuluz.ee.loaders.ComponentLoader;
 import com.kumuluz.ee.loaders.ConfigExtensionLoader;
 import com.kumuluz.ee.loaders.ExtensionLoader;
 import com.kumuluz.ee.loaders.ServerLoader;
+import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import javax.sql.XADataSource;
@@ -190,8 +193,43 @@ public class EeApplication {
                     if (dsc.getDriverClass() != null && !dsc.getDriverClass().isEmpty())
                         ds.setDriverClassName(dsc.getDriverClass());
 
-                    if (dsc.getMaxPoolSize() != null)
+                    if (dsc.getDataSourceClass() != null && !dsc.getDataSourceClass().isEmpty()) {
+                        ds.setDataSourceClassName(dsc.getDataSourceClass());
+                    }
+
+                    if (dsc.getMaxPoolSize() != null) {
                         ds.setMaximumPoolSize(dsc.getMaxPoolSize());
+                    }
+
+                    DataSourcePoolConfig dscp = dsc.getPool();
+
+                    ds.setAutoCommit(dscp.getAutoCommit());
+                    ds.setConnectionTimeout(dscp.getConnectionTimeout());
+                    ds.setIdleTimeout(dscp.getIdleTimeout());
+                    ds.setMaxLifetime(dscp.getMaxLifetime());
+                    ds.setMaximumPoolSize(dscp.getMaxSize());
+                    ds.setPoolName(dscp.getName());
+                    ds.setInitializationFailTimeout(dscp.getInitializationFailTimeout());
+                    ds.setIsolateInternalQueries(dscp.getIsolateInternalQueries());
+                    ds.setAllowPoolSuspension(dscp.getAllowPoolSuspension());
+                    ds.setReadOnly(dscp.getReadOnly());
+                    ds.setRegisterMbeans(dscp.getRegisterMbeans());
+                    ds.setValidationTimeout(dscp.getValidationTimeout());
+                    ds.setLeakDetectionThreshold(dscp.getLeakDetectionThreshold());
+
+                    if (dscp.getMinIdle() != null) {
+                        ds.setMinimumIdle(dscp.getMinIdle());
+                    }
+
+                    if (dscp.getConnectionInitSql() != null) {
+                        ds.setConnectionInitSql(dscp.getConnectionInitSql());
+                    }
+
+                    if (dscp.getTransactionIsolation() != null) {
+                        ds.setTransactionIsolation(dscp.getTransactionIsolation());
+                    }
+
+                    dsc.getProps().forEach(ds::addDataSourceProperty);
 
                     servletServer.registerDataSource(ds, dsc.getJndiName());
                 }


### PR DESCRIPTION
The internal implementations of DataSource pools is HikariCP, which can be configured with many parameters. This pull requests exposes all the available configuration options from the KumuluzEE config.

This resolves #41.