### PR TITLE
Replacement of HikariCP by IronJacamar and JCA support

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,14 +25,169 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fungal</groupId>
+            <artifactId>fungal</artifactId>
+            <version>${fungal.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-common-api</artifactId>
+            <version>${ironjacamar.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-common-impl</artifactId>
+            <version>${ironjacamar.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-common-spi</artifactId>
+            <version>${ironjacamar.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-core-api</artifactId>
+            <version>${ironjacamar.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-core-impl</artifactId>
+            <version>${ironjacamar.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.picketbox</groupId>
+                    <artifactId>picketbox</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-deployers-common</artifactId>
+            <version>${ironjacamar.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-deployers-fungal</artifactId>
+            <version>${ironjacamar.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.fungal</groupId>
+                    <artifactId>fungal</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-embedded</artifactId>
+            <version>${ironjacamar.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.fungal</groupId>
+                    <artifactId>fungal</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-jdbc</artifactId>
+            <version>${ironjacamar.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-spec-api</artifactId>
+            <version>${ironjacamar.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ironjacamar</groupId>
+            <artifactId>ironjacamar-validator</artifactId>
+            <version>${ironjacamar.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <version>${shrinkwrap.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-api-base</artifactId>
+            <version>${shrinkwrap-descriptors.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-base</artifactId>
+            <version>${shrinkwrap-descriptors.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-spi</artifactId>
+            <version>${shrinkwrap-descriptors.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <version>${shrinkwrap.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-spi</artifactId>
+            <version>${shrinkwrap.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.naming</groupId>
+            <artifactId>jnpserver</artifactId>
+            <version>${jnpserver.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging-spi</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-common-core</artifactId>
+            <version>${jboss-common-core.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging-spi</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -43,6 +198,39 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.github.fungal:fungal</include>
+                                    <include>org.jboss.naming:jnpserver</include>
+                                    <include>org.jboss:jboss-common-core</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.jboss*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/maven/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/common/src/main/java/com/kumuluz/ee/common/config/DataSourceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/DataSourceConfig.java
@@ -34,7 +34,14 @@ public class DataSourceConfig {
         private String username;
         private String password;
 
+        private Integer initialPoolSize;
+        private Integer minPoolSize;
         private Integer maxPoolSize;
+
+        private String checkConnectionSql;
+
+        private Integer blockingTimeoutMillis;
+        private Integer idleTimeoutMinutes;
 
         public Builder jndiName(String jndiName) {
             this.jndiName = jndiName;
@@ -61,8 +68,33 @@ public class DataSourceConfig {
             return this;
         }
 
+        public Builder initialPoolSize(Integer initialPoolSize) {
+            this.initialPoolSize = initialPoolSize;
+            return this;
+        }
+
+        public Builder minPoolSize(Integer minPoolSize) {
+            this.minPoolSize = minPoolSize;
+            return this;
+        }
+
         public Builder maxPoolSize(Integer maxPoolSize) {
             this.maxPoolSize = maxPoolSize;
+            return this;
+        }
+
+        public Builder checkConnectionSql(String checkConnectionSql) {
+            this.checkConnectionSql = checkConnectionSql;
+            return this;
+        }
+
+        public Builder blockingTimeoutMillis(Integer blockingTimeoutMillis) {
+            this.blockingTimeoutMillis = blockingTimeoutMillis;
+            return this;
+        }
+
+        public Builder idleTimeoutMinutes(Integer idleTimeoutMinutes) {
+            this.idleTimeoutMinutes = idleTimeoutMinutes;
             return this;
         }
 
@@ -74,7 +106,12 @@ public class DataSourceConfig {
             dataSourceConfig.connectionUrl = connectionUrl;
             dataSourceConfig.username = username;
             dataSourceConfig.password = password;
+            dataSourceConfig.initialPoolSize = initialPoolSize;
+            dataSourceConfig.minPoolSize = minPoolSize;
             dataSourceConfig.maxPoolSize = maxPoolSize;
+            dataSourceConfig.checkConnectionSql = checkConnectionSql;
+            dataSourceConfig.blockingTimeoutMillis = blockingTimeoutMillis;
+            dataSourceConfig.idleTimeoutMinutes = idleTimeoutMinutes;
 
             return dataSourceConfig;
         }
@@ -86,7 +123,14 @@ public class DataSourceConfig {
     private String username;
     private String password;
 
+    private Integer initialPoolSize;
+    private Integer minPoolSize;
     private Integer maxPoolSize;
+
+    private String checkConnectionSql;
+
+    private Integer blockingTimeoutMillis;
+    private Integer idleTimeoutMinutes;
 
     public String getJndiName() {
         return jndiName;
@@ -108,7 +152,27 @@ public class DataSourceConfig {
         return password;
     }
 
+    public Integer getInitialPoolSize() {
+        return initialPoolSize;
+    }
+
+    public Integer getMinPoolSize() {
+        return minPoolSize;
+    }
+
     public Integer getMaxPoolSize() {
         return maxPoolSize;
+    }
+
+    public String getCheckConnectionSql() {
+        return checkConnectionSql;
+    }
+
+    public Integer getBlockingTimeoutMillis() {
+        return blockingTimeoutMillis;
+    }
+
+    public Integer getIdleTimeoutMinutes() {
+        return idleTimeoutMinutes;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/XaDataSourceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/XaDataSourceConfig.java
@@ -38,6 +38,15 @@ public class XaDataSourceConfig {
 
         private Map<String, String> props = new HashMap<>();
 
+        private Integer initialPoolSize;
+        private Integer minPoolSize;
+        private Integer maxPoolSize;
+
+        private String checkConnectionSql;
+
+        private Integer blockingTimeoutMillis;
+        private Integer idleTimeoutMinutes;
+
         public Builder jndiName(String jndiName) {
             this.jndiName = jndiName;
             return this;
@@ -63,6 +72,36 @@ public class XaDataSourceConfig {
             return this;
         }
 
+        public Builder initialPoolSize(Integer initialPoolSize) {
+            this.initialPoolSize = initialPoolSize;
+            return this;
+        }
+
+        public Builder minPoolSize(Integer minPoolSize) {
+            this.minPoolSize = minPoolSize;
+            return this;
+        }
+
+        public Builder maxPoolSize(Integer maxPoolSize) {
+            this.maxPoolSize = maxPoolSize;
+            return this;
+        }
+
+        public Builder checkConnectionSql(String checkConnectionSql) {
+            this.checkConnectionSql = checkConnectionSql;
+            return this;
+        }
+
+        public Builder blockingTimeoutMillis(Integer blockingTimeoutMillis) {
+            this.blockingTimeoutMillis = blockingTimeoutMillis;
+            return this;
+        }
+
+        public Builder idleTimeoutMinutes(Integer idleTimeoutMinutes) {
+            this.idleTimeoutMinutes = idleTimeoutMinutes;
+            return this;
+        }
+
         public XaDataSourceConfig build() {
 
             XaDataSourceConfig xaDataSourceConfig = new XaDataSourceConfig();
@@ -71,6 +110,12 @@ public class XaDataSourceConfig {
             xaDataSourceConfig.username = username;
             xaDataSourceConfig.password = password;
             xaDataSourceConfig.props = props;
+            xaDataSourceConfig.initialPoolSize = initialPoolSize;
+            xaDataSourceConfig.minPoolSize = minPoolSize;
+            xaDataSourceConfig.maxPoolSize = maxPoolSize;
+            xaDataSourceConfig.checkConnectionSql = checkConnectionSql;
+            xaDataSourceConfig.blockingTimeoutMillis = blockingTimeoutMillis;
+            xaDataSourceConfig.idleTimeoutMinutes = idleTimeoutMinutes;
 
             return xaDataSourceConfig;
         }
@@ -82,6 +127,15 @@ public class XaDataSourceConfig {
     private String password;
 
     private Map<String, String> props;
+
+    private Integer initialPoolSize;
+    private Integer minPoolSize;
+    private Integer maxPoolSize;
+
+    private String checkConnectionSql;
+
+    private Integer blockingTimeoutMillis;
+    private Integer idleTimeoutMinutes;
 
     public String getJndiName() {
         return jndiName;
@@ -101,5 +155,29 @@ public class XaDataSourceConfig {
 
     public Map<String, String> getProps() {
         return props;
+    }
+
+    public Integer getInitialPoolSize() {
+        return initialPoolSize;
+    }
+
+    public Integer getMinPoolSize() {
+        return minPoolSize;
+    }
+
+    public Integer getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public String getCheckConnectionSql() {
+        return checkConnectionSql;
+    }
+
+    public Integer getBlockingTimeoutMillis() {
+        return blockingTimeoutMillis;
+    }
+
+    public Integer getIdleTimeoutMinutes() {
+        return idleTimeoutMinutes;
     }
 }

--- a/common/src/main/java/com/kumuluz/ee/common/datasources/NonJtaXAConnectionWrapper.java
+++ b/common/src/main/java/com/kumuluz/ee/common/datasources/NonJtaXAConnectionWrapper.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executor;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public class NonJtaXAConnectionWrapper implements Connection {
 
     private Boolean isClosed = false;

--- a/common/src/main/java/com/kumuluz/ee/common/datasources/NonJtaXADataSourceWrapper.java
+++ b/common/src/main/java/com/kumuluz/ee/common/datasources/NonJtaXADataSourceWrapper.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public class NonJtaXADataSourceWrapper implements XADataSourceWrapper {
 
     protected XADataSource xaDataSource;

--- a/common/src/main/java/com/kumuluz/ee/common/datasources/XADataSourceBuilder.java
+++ b/common/src/main/java/com/kumuluz/ee/common/datasources/XADataSourceBuilder.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public class XADataSourceBuilder {
 
     private XaDataSourceConfig xaDataSourceConfig;

--- a/common/src/main/java/com/kumuluz/ee/common/datasources/XADataSourceWrapper.java
+++ b/common/src/main/java/com/kumuluz/ee/common/datasources/XADataSourceWrapper.java
@@ -26,5 +26,6 @@ import javax.sql.DataSource;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public interface XADataSourceWrapper extends DataSource {
 }

--- a/common/src/main/java/com/kumuluz/ee/common/filters/JcaServletListener.java
+++ b/common/src/main/java/com/kumuluz/ee/common/filters/JcaServletListener.java
@@ -1,0 +1,159 @@
+package com.kumuluz.ee.common.filters;
+
+import com.kumuluz.ee.common.config.DataSourceConfig;
+import com.kumuluz.ee.common.config.EeConfig;
+import com.kumuluz.ee.common.config.XaDataSourceConfig;
+import com.kumuluz.ee.common.jca.JcaEmbeddedDeployer;
+import com.kumuluz.ee.common.jca.DriverInfo;
+import com.kumuluz.ee.common.jca.ResourceAdapterHelper;
+import com.kumuluz.ee.common.runtime.EeRuntimeInternal;
+import com.kumuluz.ee.common.utils.StringUtils;
+import org.jboss.jca.embedded.Embedded;
+import org.jboss.jca.embedded.dsl.datasources13.api.DatasourceType;
+import org.jboss.jca.embedded.dsl.datasources13.api.DatasourcesDescriptor;
+import org.jboss.jca.embedded.dsl.datasources13.api.XaDatasourceType;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+
+import javax.servlet.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class JcaServletListener implements ServletContextListener {
+
+    private EeRuntimeInternal eeRuntimeInternal;
+    private EeConfig eeConfig;
+    private boolean jtaPresent;
+
+    public JcaServletListener(EeRuntimeInternal eeRuntimeInternal, EeConfig eeConfig, boolean jtaPresent) {
+        this.eeRuntimeInternal = eeRuntimeInternal;
+        this.eeConfig = eeConfig;
+        this.jtaPresent = jtaPresent;
+
+        // Initiate the IronJacamar
+        JcaEmbeddedDeployer jca = JcaEmbeddedDeployer.getInstance();
+        jca.start();
+
+        // Deploy IronJacamar's profiles
+        jca.deploy(Embedded.class, "naming.xml");
+        jca.deploy(Embedded.class, (jtaPresent ? "transaction.xml" : "noop-transaction.xml"));
+        jca.deploy(JcaServletListener.class, "jca.xml");
+        jca.deploy(Embedded.class, "ds.xml");
+
+        // Deploy JDBC Local/XA Resource Adapters
+        if (!eeConfig.getDatasources().isEmpty()) {
+            jca.deploy(ResourceAdapterHelper.getJdbcLocalRAR());
+        }
+
+        if (!eeConfig.getXaDatasources().isEmpty()) {
+            jca.deploy(ResourceAdapterHelper.getJdbcXaRAR());
+        }
+
+        // Deploy Local/XA Datasources
+        jca.deploy(createDatasourcesDescriptor());
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+        JcaEmbeddedDeployer.getInstance().stop();
+    }
+
+    private DatasourcesDescriptor createDatasourcesDescriptor() {
+        String descriptorName = String.format("kumuluz-%s-ds.xml", eeRuntimeInternal.getInstanceId());
+
+        DatasourcesDescriptor descriptor = Descriptors.create(DatasourcesDescriptor.class, descriptorName);
+
+        eeConfig.getDatasources().forEach(dsc -> addLocalDataSource(descriptor, dsc));
+
+        eeConfig.getXaDatasources().forEach(xdsc -> addXaDataSource(descriptor, xdsc));
+
+        return descriptor;
+    }
+
+    private void addLocalDataSource(DatasourcesDescriptor descriptor, DataSourceConfig dsc) {
+        DatasourceType<DatasourcesDescriptor> ds = descriptor.createDatasource()
+                .jndiName(dsc.getJndiName())
+                .poolName(UUID.randomUUID().toString())
+                .jta(jtaPresent);
+
+        DriverInfo.fromJdbcUrl(dsc.getConnectionUrl()).ifPresent(driver -> {
+            ds.driverClass(driver.getDriverClassName());
+
+            ds.newConnectionSql(driver.getCheckConnectionSql());
+            ds.getOrCreateValidation().checkValidConnectionSql(driver.getCheckConnectionSql());
+        });
+
+        ds.connectionUrl(dsc.getConnectionUrl());
+
+        if (!StringUtils.isNullOrEmpty(dsc.getDriverClass())) {
+            ds.driverClass(dsc.getDriverClass());
+        }
+
+        ds.getOrCreateSecurity()
+                .userName(dsc.getUsername())
+                .password(dsc.getPassword());
+
+        // Conection pool properties
+        Optional.ofNullable(dsc.getInitialPoolSize()).ifPresent(v -> ds.getOrCreatePool().initialPoolSize(v));
+        Optional.ofNullable(dsc.getMinPoolSize()).ifPresent(v -> ds.getOrCreatePool().minPoolSize(v));
+        Optional.ofNullable(dsc.getMaxPoolSize()).ifPresent(v -> ds.getOrCreatePool().maxPoolSize(v));
+
+        // Connection validation properties
+        if (!StringUtils.isNullOrEmpty(dsc.getCheckConnectionSql())) {
+            ds.newConnectionSql(dsc.getCheckConnectionSql());
+            ds.getOrCreateValidation().checkValidConnectionSql(dsc.getCheckConnectionSql());
+        }
+
+        // Timeout properties
+        Optional.ofNullable(dsc.getBlockingTimeoutMillis()).ifPresent(v -> ds.getOrCreateTimeout().blockingTimeoutMillis(v));
+        Optional.ofNullable(dsc.getIdleTimeoutMinutes()).ifPresent(v -> ds.getOrCreateTimeout().idleTimeoutMinutes(v));
+    }
+
+    private void addXaDataSource(DatasourcesDescriptor descriptor, XaDataSourceConfig xdsc) {
+        XaDatasourceType<DatasourcesDescriptor> ds = descriptor.createXaDatasource()
+                .jndiName(xdsc.getJndiName())
+                .poolName(UUID.randomUUID().toString());
+
+        DriverInfo.fromXaDataSourceClass(xdsc.getXaDatasourceClass()).ifPresent(driver -> {
+            ds.newConnectionSql(driver.getCheckConnectionSql());
+            ds.getOrCreateValidation().checkValidConnectionSql(driver.getCheckConnectionSql());
+        });
+
+        ds.xaDatasourceClass(xdsc.getXaDatasourceClass());
+
+		/*
+		 * Uses "xa-datasource-property" because IronJacamar doesn't send security info correctly
+		 */
+        ds.createXaDatasourceProperty().name("User").text(xdsc.getUsername());
+        ds.createXaDatasourceProperty().name("Password").text(xdsc.getPassword());
+
+        for (Map.Entry<String, String> property : xdsc.getProps().entrySet()) {
+            ds.createXaDatasourceProperty().name(property.getKey()).text(property.getValue());
+        }
+
+        // Conection pool properties
+        Optional.ofNullable(xdsc.getInitialPoolSize()).ifPresent(v -> ds.getOrCreateXaPool().initialPoolSize(v));
+        Optional.ofNullable(xdsc.getMinPoolSize()).ifPresent(v -> ds.getOrCreateXaPool().minPoolSize(v));
+        Optional.ofNullable(xdsc.getMaxPoolSize()).ifPresent(v -> ds.getOrCreateXaPool().maxPoolSize(v));
+
+        // Connection validation properties
+        if (!StringUtils.isNullOrEmpty(xdsc.getCheckConnectionSql())) {
+            ds.newConnectionSql(xdsc.getCheckConnectionSql());
+            ds.getOrCreateValidation().checkValidConnectionSql(xdsc.getCheckConnectionSql());
+        }
+
+        // Timeout properties
+        Optional.ofNullable(xdsc.getBlockingTimeoutMillis()).ifPresent(v -> ds.getOrCreateTimeout().blockingTimeoutMillis(v));
+        Optional.ofNullable(xdsc.getIdleTimeoutMinutes()).ifPresent(v -> ds.getOrCreateTimeout().idleTimeoutMinutes(v));
+    }
+
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/DriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/DriverInfo.java
@@ -1,0 +1,76 @@
+package com.kumuluz.ee.common.jca;
+
+import com.kumuluz.ee.common.utils.StringUtils;
+
+import java.util.*;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class DriverInfo {
+
+    private static Set<DriverInfo> drivers;
+
+    private String driverClassName;
+    private String xaDataSourceClassName;
+    private String checkConnectionSql;
+
+    public DriverInfo(String driverClassName, String xaDataSourceClassName, String checkConnectionSql) {
+        Objects.requireNonNull(driverClassName, "Driver Class is required!");
+        Objects.requireNonNull(checkConnectionSql, "Check Connection SQL is required!");
+
+        this.driverClassName = driverClassName;
+        this.xaDataSourceClassName = xaDataSourceClassName;
+        this.checkConnectionSql = checkConnectionSql;
+    }
+
+    public String getProductName() {
+        return getClass().getSimpleName().replace(DriverInfo.class.getSimpleName(), "").toLowerCase();
+    }
+
+    public String getDriverClassName() {
+        return driverClassName;
+    }
+
+    public String getXaDataSourceClassName() {
+        return xaDataSourceClassName;
+    }
+
+    public String getCheckConnectionSql() {
+        return checkConnectionSql;
+    }
+
+    public boolean matcheJdbcUrl(String jdbcUrl) {
+        if (StringUtils.isNullOrEmpty(jdbcUrl)) {
+            return false;
+        }
+        return jdbcUrl.matches(String.format("^(jdbc:%s:).*", getProductName()));
+    }
+
+    private static Set<DriverInfo> getJdbcDrivers() {
+        if (Objects.isNull(drivers)) {
+            drivers = new HashSet<>();
+            ServiceLoader.load(DriverInfo.class).forEach(drivers::add);
+        }
+        return drivers;
+    }
+
+    public static Optional<DriverInfo> fromJdbcUrl(String jdbcUrl) {
+        if (StringUtils.isNullOrEmpty(jdbcUrl)) {
+            return Optional.empty();
+        }
+        return getJdbcDrivers().stream()
+                .filter(driver -> driver.matcheJdbcUrl(jdbcUrl))
+                .findFirst();
+    }
+
+    public static Optional<DriverInfo> fromXaDataSourceClass(String xaDsClassName) {
+        if (StringUtils.isNullOrEmpty(xaDsClassName)) {
+            return Optional.empty();
+        }
+        return getJdbcDrivers().stream()
+                .filter(driver -> Objects.equals(driver.getXaDataSourceClassName(), xaDsClassName))
+                .findFirst();
+    }
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/JcaEmbeddedDeployer.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/JcaEmbeddedDeployer.java
@@ -1,0 +1,147 @@
+package com.kumuluz.ee.common.jca;
+
+import com.kumuluz.ee.common.exceptions.KumuluzServerException;
+import org.jboss.jca.embedded.Embedded;
+import org.jboss.jca.embedded.EmbeddedFactory;
+import org.jboss.jca.embedded.dsl.InputStreamDescriptor;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import javax.naming.Context;
+import java.io.ByteArrayInputStream;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.Map.Entry;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class JcaEmbeddedDeployer {
+
+    private static final Charset DESCRIPTOR_CHARSET = Charset.forName("UTF-8");
+    private static JcaEmbeddedDeployer INSTANCE;
+
+    private Embedded container;
+
+    private boolean started;
+    private List<URL> resources;
+    private List<ResourceAdapterArchive> resourceAdapters;
+    private Map<Descriptor, InputStreamDescriptor> descriptors;
+
+    private JcaEmbeddedDeployer() {
+        /*
+         * Setup JBoss JNDI
+         */
+        System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "org.jnp.interfaces.NamingContextFactory");
+        System.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.naming:org.jnp.interfaces");
+
+		/*
+		 * Prepare Embedded JCA container
+		 */
+        this.container = EmbeddedFactory.create(false);
+        this.started = false;
+
+        this.resources = new ArrayList<>();
+        this.resourceAdapters = new ArrayList<>();
+        this.descriptors = new LinkedHashMap<>();
+    }
+
+    public static JcaEmbeddedDeployer getInstance() {
+        if (Objects.isNull(INSTANCE)) {
+            INSTANCE = new JcaEmbeddedDeployer();
+        }
+        return INSTANCE;
+    }
+
+    private void checkState() {
+        if (!started) {
+            throw new KumuluzServerException("The JCA container is not started!");
+        }
+    }
+
+    public void start() {
+        try {
+            container.startup();
+            started = true;
+        } catch (Throwable e) {
+            throw new KumuluzServerException("An error occurred while starting the JCA container", e);
+        }
+    }
+
+    public void deploy(Class<?> clazz, String name) {
+        deploy(clazz.getClassLoader().getResource(name));
+    }
+
+    private void deploy(URL resource) {
+        checkState();
+
+        try {
+            resources.add(resource);
+            container.deploy(resource);
+        } catch (Throwable e) {
+            String msg = String.format("An errror occurred while deploying the resource: \"%s\"", resource.getFile());
+            throw new KumuluzServerException(msg, e);
+        }
+    }
+
+    public void deploy(ResourceAdapterArchive raa) {
+        checkState();
+
+        try {
+            resourceAdapters.add(raa);
+            container.deploy(raa);
+        } catch (Throwable e) {
+            String msg = String.format("An errror occurred while deploying the Resource Adapter: \"%s\"", raa.getName());
+            throw new KumuluzServerException(msg, e);
+        }
+    }
+
+    public void deploy(Descriptor descriptor) {
+        checkState();
+
+        try {
+            InputStreamDescriptor isd = new InputStreamDescriptor(descriptor.getDescriptorName(),
+                new ByteArrayInputStream(descriptor.exportAsString().getBytes(DESCRIPTOR_CHARSET))
+            );
+            descriptors.put(descriptor, isd);
+            container.deploy(isd);
+        } catch (Throwable e) {
+            String msg = String.format("An error occurred while deploying the descriptor: \"%s\"", descriptor.getDescriptorName());
+            throw new KumuluzServerException(msg, e);
+        }
+    }
+
+    public void stop() {
+        checkState();
+
+        try {
+            Iterator<Entry<Descriptor, InputStreamDescriptor>> descriptorsIterator = descriptors.entrySet().stream().sorted(Collections.reverseOrder()).iterator();
+
+            while (descriptorsIterator.hasNext()) {
+                container.undeploy(descriptorsIterator.next().getValue());
+                descriptorsIterator.remove();
+            }
+
+            Iterator<ResourceAdapterArchive> resourceAdaptersIterator = resourceAdapters.stream().sorted(Collections.reverseOrder()).iterator();
+
+            while (resourceAdaptersIterator.hasNext()) {
+                container.undeploy(resourceAdaptersIterator.next());
+                resourceAdaptersIterator.remove();
+            }
+
+            Iterator<URL> resourcesIterator = resources.stream().sorted(Collections.reverseOrder()).iterator();
+
+            while (resourcesIterator.hasNext()) {
+                container.undeploy(resourcesIterator.next());
+                resourcesIterator.remove();
+            }
+
+            container.shutdown();
+            started = false;
+        } catch (Throwable e) {
+            throw new KumuluzServerException("An error occurred while stopping the JCA container", e);
+        }
+    }
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/ResourceAdapterHelper.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/ResourceAdapterHelper.java
@@ -1,0 +1,48 @@
+package com.kumuluz.ee.common.jca;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+
+import java.util.Objects;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class ResourceAdapterHelper {
+
+    private static JavaArchive ironJacamarJdbcJar;
+    private static ResourceAdapterArchive jdbcLocalRar;
+    private static ResourceAdapterArchive jdbcXaRar;
+
+    private ResourceAdapterHelper() {
+    }
+
+    private static JavaArchive getJdbcResourceAdapter() {
+        if (Objects.isNull(ironJacamarJdbcJar)) {
+            ironJacamarJdbcJar = ShrinkWrap.create(JavaArchive.class, "ironjacamar-jdbc.jar")
+                    .addPackages(true, org.jboss.jca.adapters.AdaptersBundle.class.getPackage())
+                    .addAsResource("jdbc.properties");
+        }
+        return ironJacamarJdbcJar;
+    }
+
+    public static ResourceAdapterArchive getJdbcLocalRAR() {
+        if (Objects.isNull(jdbcLocalRar)) {
+            jdbcLocalRar = ShrinkWrap.create(ResourceAdapterArchive.class, "jdbc-local.rar")
+                    .addAsManifestResource("jdbc-local-ra.xml", "ra.xml")
+                    .addAsLibrary(getJdbcResourceAdapter());
+        }
+        return jdbcLocalRar;
+    }
+
+    public static ResourceAdapterArchive getJdbcXaRAR() {
+        if (Objects.isNull(jdbcXaRar)) {
+            jdbcXaRar = ShrinkWrap.create(ResourceAdapterArchive.class, "jdbc-xa.rar")
+                    .addAsManifestResource("jdbc-xa-ra.xml", "ra.xml")
+                    .addAsLibrary(getJdbcResourceAdapter());
+        }
+        return jdbcXaRar;
+    }
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/DB2DriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/DB2DriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class DB2DriverInfo extends DriverInfo {
+
+    public DB2DriverInfo() {
+        super("com.ibm.db2.jcc.DB2Driver", "com.ibm.db2.jdbc.DB2XADataSource", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+    }
+
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/DerbyDriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/DerbyDriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class DerbyDriverInfo extends DriverInfo {
+
+    public DerbyDriverInfo() {
+        super("org.apache.derby.jdbc.ClientDriver", "org.apache.derby.jdbc.ClientXADataSource", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+    }
+
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/H2DriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/H2DriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class H2DriverInfo extends DriverInfo {
+
+    public H2DriverInfo() {
+        super("org.h2.Driver", "org.h2.jdbcx.JdbcDataSource", "SELECT 1");
+    }
+
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/MariaDBDriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/MariaDBDriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class MariaDBDriverInfo extends DriverInfo {
+
+    public MariaDBDriverInfo() {
+        super("org.mariadb.jdbc.Driver", "org.mariadb.jdbc.MariaDbDataSource", "SELECT 1");
+    }
+    
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/MySQLDriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/MySQLDriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class MySQLDriverInfo extends DriverInfo {
+
+    public MySQLDriverInfo() {
+        super("com.mysql.jdbc.Driver", "com.mysql.jdbc.jdbc2.optional.MysqlXADataSource", "SELECT 1");
+    }
+    
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/OracleDriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/OracleDriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class OracleDriverInfo extends DriverInfo {
+
+    public OracleDriverInfo() {
+        super("oracle.jdbc.OracleDriver", "oracle.jdbc.xa.client.OracleXADataSource", "SELECT 'Hello' from DUAL");
+    }
+    
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/PostgreSQLDriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/PostgreSQLDriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class PostgreSQLDriverInfo extends DriverInfo {
+
+    public PostgreSQLDriverInfo() {
+        super("org.postgresql.Driver", "org.postgresql.xa.PGXADataSource", "SELECT 1");
+    }
+
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/SQLServerDriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/SQLServerDriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class SQLServerDriverInfo extends DriverInfo {
+
+    public SQLServerDriverInfo() {
+        super("com.microsoft.sqlserver.jdbc.SQLServerDriver", "com.microsoft.sqlserver.jdbc.SQLServerXADataSource", "SELECT 1");
+    }
+
+}

--- a/common/src/main/java/com/kumuluz/ee/common/jca/drivers/SybaseDriverInfo.java
+++ b/common/src/main/java/com/kumuluz/ee/common/jca/drivers/SybaseDriverInfo.java
@@ -1,0 +1,15 @@
+package com.kumuluz.ee.common.jca.drivers;
+
+import com.kumuluz.ee.common.jca.DriverInfo;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class SybaseDriverInfo extends DriverInfo {
+
+    public SybaseDriverInfo() {
+        super("com.sybase.jdbc4.jdbc.SybDriver", "com.sybase.jdbc4.jdbc.SybXADataSource", "SELECT 1");
+    }
+
+}

--- a/common/src/main/java/com/kumuluz/ee/common/utils/StringUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/common/utils/StringUtils.java
@@ -53,10 +53,10 @@ public class StringUtils {
     }
 
     /**
-     * Parse lower hyphen case to upper camel case.
+     * Parse lower hyphen case to camel case.
      *
      * @param s string in lower hyphen case format
-     * @return string in upper camel case format
+     * @return string in camel case format
      */
     public static String hyphenCaseToCamelCase(String s) {
 
@@ -77,6 +77,21 @@ public class StringUtils {
     }
 
     /**
+     * Parse lower hyphen case to upper camel case.
+     *
+     * @param s string in lower hyphen case format
+     * @return string in upper camel case format
+     */
+    public static String hyphenCaseToUpperCamelCase(String s) {
+        StringBuilder parsedString = new StringBuilder();
+
+        Stream.of(s.split("-")).filter(w -> !"".equals(w))
+                .forEach(w -> parsedString.append(Character.toUpperCase(w.charAt(0))).append(w.substring(1)));
+
+        return parsedString.toString();
+    }
+
+    /**
      * Check whether the string is null or empty
      *
      * @param s string to check.
@@ -85,4 +100,16 @@ public class StringUtils {
     public static boolean isNullOrEmpty(String s) {
         return s == null || s.isEmpty();
     }
+
+    /**
+     * Splits a string separated by a regex into a list of strings
+     *
+     * @param s string to be splitted
+     * @param regex string used to split previous param
+     * @return string list containing the parts of the first parameter separated by the regex
+     */
+    public static List<String> splitToList(String s, String regex) {
+        return Stream.of(s.split(regex)).map(String::trim).collect(Collectors.toList());
+    }
+
 }

--- a/common/src/main/java/com/kumuluz/ee/logs/SysoutPrintStream.java
+++ b/common/src/main/java/com/kumuluz/ee/logs/SysoutPrintStream.java
@@ -1,0 +1,17 @@
+package com.kumuluz.ee.logs;
+
+import java.io.PrintStream;
+
+/**
+ * Directs messages from IronJacamar to System.out. This avoids the need for jboss-stdio dependency.
+ *
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class SysoutPrintStream extends PrintStream {
+
+    public SysoutPrintStream() {
+    	super(System.out, true);
+    }
+	
+}

--- a/common/src/main/resources/META-INF/services/com.kumuluz.ee.common.jca.DriverInfo
+++ b/common/src/main/resources/META-INF/services/com.kumuluz.ee.common.jca.DriverInfo
@@ -1,0 +1,9 @@
+com.kumuluz.ee.common.jca.drivers.DB2DriverInfo
+com.kumuluz.ee.common.jca.drivers.DerbyDriverInfo
+com.kumuluz.ee.common.jca.drivers.H2DriverInfo
+com.kumuluz.ee.common.jca.drivers.MariaDBDriverInfo
+com.kumuluz.ee.common.jca.drivers.MySQLDriverInfo
+com.kumuluz.ee.common.jca.drivers.OracleDriverInfo
+com.kumuluz.ee.common.jca.drivers.PostgreSQLDriverInfo
+com.kumuluz.ee.common.jca.drivers.SQLServerDriverInfo
+com.kumuluz.ee.common.jca.drivers.SybaseDriverInfo

--- a/common/src/main/resources/jca.xml
+++ b/common/src/main/resources/jca.xml
@@ -1,0 +1,399 @@
+<deployment>
+
+	<!-- Bean Validation
+
+         PS: Keep this element commented until the BeanValidation JCA deployment could be activated on presence respective Kumuluz Component.
+
+	<bean name="BeanValidation" class="org.jboss.jca.core.bv.BeanValidation">
+		<depends>NamingServer</depends>
+	</bean>
+	-->
+	
+	<!-- This class replaces JBoss Stdio dependency -->
+	<bean name="KumuluzStdio" class="com.kumuluz.ee.logs.SysoutPrintStream">
+	</bean>
+
+	<!-- Thread group -->
+	<bean name="ThreadGroup" class="java.lang.ThreadGroup">
+		<constructor>
+			<parameter>workmanager</parameter>
+		</constructor>
+		<ignoreStop />
+		<ignoreDestroy />
+	</bean>
+
+	<!-- Thread factory -->
+	<bean name="ThreadFactory" interface="java.util.concurrent.ThreadFactory"
+		class="org.jboss.threads.JBossThreadFactory">
+		<constructor>
+			<parameter>
+				<inject bean="ThreadGroup" />
+			</parameter>
+			<parameter>false</parameter>
+			<parameter>5</parameter>
+			<parameter>work</parameter>
+			<parameter>
+				<null />
+			</parameter>
+			<parameter>
+				<null />
+			</parameter>
+		</constructor>
+	</bean>
+
+	<!-- Rejecting executor -->
+	<bean name="RejectingExecutor">
+		<constructor factoryMethod="rejectingExecutor"
+			factoryClass="org.jboss.threads.JBossExecutors">
+		</constructor>
+	</bean>
+
+	<!-- TimeUnit -->
+	<bean name="KeepAliveTimeUnit">
+		<constructor factoryMethod="valueOf" factoryClass="java.util.concurrent.TimeUnit">
+			<parameter>SECONDS</parameter>
+		</constructor>
+	</bean>
+
+	<!-- Short running thread pool -->
+	<bean name="ShortRunningThreadPool" class="org.jboss.threads.QueueExecutor">
+		<constructor>
+			<!-- Core threads -->
+			<parameter>20</parameter>
+			<!-- Max threads -->
+			<parameter>100</parameter>
+			<!-- 60 seconds keepalive -->
+			<parameter>60</parameter>
+			<parameter>
+				<inject bean="KeepAliveTimeUnit" />
+			</parameter>
+			<!-- Queue size -->
+			<parameter>1024</parameter>
+			<!-- Thread factory -->
+			<parameter>
+				<inject bean="ThreadFactory" />
+			</parameter>
+			<!-- Blocking -->
+			<parameter>true</parameter>
+			<!-- Handoff executor -->
+			<parameter>
+				<inject bean="RejectingExecutor" />
+			</parameter>
+		</constructor>
+		<destroy method="shutdown" />
+	</bean>
+
+	<!-- Long running thread pool -->
+	<bean name="LongRunningThreadPool" class="org.jboss.threads.QueueExecutor">
+		<constructor>
+			<!-- Core threads -->
+			<parameter>20</parameter>
+			<!-- Max threads -->
+			<parameter>100</parameter>
+			<!-- 60 seconds keepalive -->
+			<parameter>60</parameter>
+			<parameter>
+				<inject bean="KeepAliveTimeUnit" />
+			</parameter>
+			<!-- Queue size -->
+			<parameter>1024</parameter>
+			<!-- Thread factory -->
+			<parameter>
+				<inject bean="ThreadFactory" />
+			</parameter>
+			<!-- Blocking -->
+			<parameter>true</parameter>
+			<!-- Handoff executor -->
+			<parameter>
+				<inject bean="RejectingExecutor" />
+			</parameter>
+		</constructor>
+		<destroy method="shutdown" />
+	</bean>
+
+	<!-- Callback -->
+	<bean name="Callback" interface="org.jboss.jca.core.spi.security.Callback"
+		class="org.jboss.jca.core.security.DefaultCallback" />
+
+	<!-- PicketBox -->
+	<bean name="PicketBox"
+		class="org.jboss.jca.core.security.picketbox.PicketBoxSecurityIntegration">
+	</bean>
+
+	<!-- Idle remover -->
+	<bean name="IdleRemover">
+		<constructor
+			factoryClass="org.jboss.jca.core.connectionmanager.pool.idle.IdleRemover"
+			factoryMethod="getInstance">
+		</constructor>
+	</bean>
+
+	<!-- Connection validator -->
+	<bean name="ConnectionValidator">
+		<constructor
+			factoryClass="org.jboss.jca.core.connectionmanager.pool.validator.ConnectionValidator"
+			factoryMethod="getInstance">
+		</constructor>
+	</bean>
+
+	<!-- Work Manager -->
+	<bean name="WorkManager" interface="org.jboss.jca.core.api.workmanager.WorkManager"
+		class="org.jboss.jca.core.workmanager.WorkManagerImpl">
+
+		<!-- The name -->
+		<property name="Name">Default</property>
+
+		<!-- The short running thread pool -->
+		<property name="ShortRunningThreadPool">
+			<inject bean="ShortRunningThreadPool" />
+		</property>
+
+		<!-- The long running thread pool -->
+		<property name="LongRunningThreadPool">
+			<inject bean="LongRunningThreadPool" />
+		</property>
+
+		<!-- The XA terminator -->
+		<property name="XATerminator">
+			<inject bean="TransactionIntegration" property="XATerminator" />
+		</property>
+
+		<!-- The callback security module -->
+		<property name="CallbackSecurity">
+			<inject bean="Callback" />
+		</property>
+
+		<!-- The security integration module -->
+		<property name="SecurityIntegration">
+			<inject bean="PicketBox" />
+		</property>
+
+		<destroy method="shutdown" />
+	</bean>
+
+	<!-- Work Manager Coordinator -->
+	<bean name="WorkManagerCoordinator">
+		<constructor factoryClass="org.jboss.jca.core.workmanager.WorkManagerCoordinator"
+			factoryMethod="getInstance" />
+
+		<property name="DefaultWorkManager">
+			<inject bean="WorkManager" />
+		</property>
+
+		<incallback method="registerWorkManager" />
+		<uncallback method="unregisterWorkManager" />
+	</bean>
+
+	<!-- Default Bootstrap context -->
+	<bean name="DefaultBootstrapContext"
+		interface="org.jboss.jca.core.api.bootstrap.CloneableBootstrapContext"
+		class="org.jboss.jca.core.bootstrapcontext.BaseCloneableBootstrapContext">
+
+		<!-- The Name -->
+		<property name="Name">Default</property>
+
+		<!-- The Transaction Synchronization Registry -->
+		<property name="TransactionSynchronizationRegistry">
+			<inject bean="TransactionSynchronizationRegistry" />
+		</property>
+
+		<!-- The Work Manager -->
+		<property name="WorkManagerName">
+			<inject bean="WorkManager" property="Name" />
+		</property>
+
+		<!-- The XA terminator -->
+		<property name="XATerminator">
+			<inject bean="TransactionIntegration" property="XATerminator" />
+		</property>
+	</bean>
+
+	<!-- Bootstrap Context Coordinator -->
+	<bean name="BootstrapContextCoordinator">
+		<constructor
+			factoryClass="org.jboss.jca.core.bootstrapcontext.BootstrapContextCoordinator"
+			factoryMethod="getInstance" />
+
+		<property name="DefaultBootstrapContext">
+			<inject bean="DefaultBootstrapContext" />
+		</property>
+
+		<incallback method="registerBootstrapContext" />
+		<uncallback method="unregisterBootstrapContext" />
+	</bean>
+
+	<!-- Explicit JNDI strategy -->
+	<bean name="ExplicitJndiStrategy" interface="org.jboss.jca.core.spi.naming.JndiStrategy"
+		class="org.jboss.jca.core.naming.ExplicitJndiStrategy" />
+
+	<!-- Simple JNDI strategy -->
+	<bean name="SimpleJndiStrategy" interface="org.jboss.jca.core.spi.naming.JndiStrategy"
+		class="org.jboss.jca.core.naming.SimpleJndiStrategy" />
+
+	<!-- MDR -->
+	<bean name="MDR" interface="org.jboss.jca.core.spi.mdr.MetadataRepository"
+		class="org.jboss.jca.core.mdr.SimpleMetadataRepository" />
+
+	<!-- CCM -->
+	<bean name="CCM"
+		interface="org.jboss.jca.core.api.connectionmanager.ccm.CachedConnectionManager"
+		class="org.jboss.jca.core.connectionmanager.ccm.CachedConnectionManagerImpl">
+		<constructor>
+			<parameter>
+				<inject bean="TransactionIntegration" />
+			</parameter>
+		</constructor>
+		<property name="Debug">false</property>
+		<property name="Error">false</property>
+	</bean>
+
+	<!-- Resource adapter repository -->
+	<bean name="ResourceAdapterRepository" interface="org.jboss.jca.core.spi.rar.ResourceAdapterRepository"
+		class="org.jboss.jca.core.rar.SimpleResourceAdapterRepository">
+		<property name="MetadataRepository">
+			<inject bean="MDR" />
+		</property>
+		<property name="TransactionIntegration">
+			<null />
+		</property>
+	</bean>
+
+	<!-- Management repository -->
+	<bean name="ManagementRepository"
+		class="org.jboss.jca.core.api.management.ManagementRepository" />
+
+	<!-- SubjectFactory -->
+	<bean name="DefaultSecurityDomain" interface="org.jboss.jca.core.spi.security.SubjectFactory"
+		class="org.jboss.jca.core.security.DefaultSubjectFactory">
+		<property name="SecurityDomain">DefaultSecurityDomain</property>
+		<property name="UserName">user</property>
+		<property name="Password">password</property>
+	</bean>
+
+	<!-- Deployer configuration -->
+	<bean name="DeployerConfiguration" class="org.jboss.jca.deployers.fungal.RAConfiguration">
+		<property name="ArchiveValidation">true</property>
+		<property name="ArchiveValidationFailOnWarn">false</property>
+		<property name="ArchiveValidationFailOnError">true</property>
+		<property name="BeanValidation">false</property>
+
+		<property name="PrintStream">
+			<inject bean="KumuluzStdio" />
+		</property>
+
+		<property name="JndiStrategy">
+			<inject bean="ExplicitJndiStrategy" />
+		</property>
+		<property name="TransactionIntegration">
+			<inject bean="TransactionIntegration" />
+		</property>
+		<property name="MetadataRepository">
+			<inject bean="MDR" />
+		</property>
+		<property name="ManagementRepository">
+			<inject bean="ManagementRepository" />
+		</property>
+		<property name="ResourceAdapterRepository">
+			<inject bean="ResourceAdapterRepository" />
+		</property>
+		<property name="CachedConnectionManager">
+			<inject bean="CCM" />
+		</property>
+	</bean>
+
+	<!-- Activator configuration -->
+	<bean name="ActivatorConfiguration" class="org.jboss.jca.deployers.fungal.RAConfiguration">
+		<property name="ArchiveValidation">true</property>
+		<property name="ArchiveValidationFailOnWarn">false</property>
+		<property name="ArchiveValidationFailOnError">true</property>
+		<property name="BeanValidation">false</property>
+		
+		<property name="PrintStream">
+			<inject bean="KumuluzStdio" />
+		</property>
+		
+		<property name="JndiStrategy">
+			<inject bean="SimpleJndiStrategy" />
+		</property>
+		<property name="TransactionIntegration">
+			<inject bean="TransactionIntegration" />
+		</property>
+		<property name="MetadataRepository">
+			<inject bean="MDR" />
+		</property>
+		<property name="ManagementRepository">
+			<inject bean="ManagementRepository" />
+		</property>
+		<property name="ResourceAdapterRepository">
+			<inject bean="ResourceAdapterRepository" />
+		</property>
+		<property name="CachedConnectionManager">
+			<inject bean="CCM" />
+		</property>
+	</bean>
+
+	<!-- RA deployer -->
+	<bean name="RADeployer" interface="com.github.fungal.spi.deployers.Deployer"
+		class="org.jboss.jca.deployers.fungal.RADeployer">
+		
+		<property name="Configuration">
+			<inject bean="DeployerConfiguration" />
+		</property>
+		<property name="Kernel">
+			<inject bean="Kernel" />
+		</property>
+		
+		<!--
+		<depends>BeanValidation</depends>
+		<depends>JBossStdioContextSelector</depends>
+		-->
+		
+		<depends>IdleRemover</depends>
+		<depends>ConnectionValidator</depends>
+	</bean>
+
+	<!-- -ra.xml deployer -->
+	<bean name="RaXmlDeployer" interface="com.github.fungal.spi.deployers.Deployer"
+		class="org.jboss.jca.deployers.fungal.RaXmlDeployer">
+		<property name="Configuration">
+			<inject bean="DeployerConfiguration" />
+		</property>
+		<property name="Kernel">
+			<inject bean="Kernel" />
+		</property>
+		
+		<!--
+		<depends>BeanValidation</depends>
+		<depends>JBossStdioContextSelector</depends>
+		-->
+		
+		<depends>IdleRemover</depends>
+		<depends>ConnectionValidator</depends>
+	</bean>
+
+	<!-- RA activator -->
+	<bean name="RAActivator" class="org.jboss.jca.deployers.fungal.RAActivator">
+		<property name="Configuration">
+			<inject bean="ActivatorConfiguration" />
+		</property>
+		<property name="Enabled">true</property>
+		<property name="Kernel">
+			<inject bean="Kernel" />
+		</property>
+		<property name="ExcludeArchives">
+			<set elementClass="java.lang.String">
+				<value>jdbc-local.rar</value>
+				<value>jdbc-xa.rar</value>
+			</set>
+		</property>
+		
+		<!--
+		<depends>BeanValidation</depends>
+		<depends>JBossStdioContextSelector</depends>
+		-->
+		
+		<depends>IdleRemover</depends>
+		<depends>ConnectionValidator</depends>
+	</bean>
+
+</deployment>

--- a/common/src/main/resources/jdbc-local-ra.xml
+++ b/common/src/main/resources/jdbc-local-ra.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<connector xmlns="http://java.sun.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+           http://java.sun.com/xml/ns/j2ee/connector_1_6.xsd"
+           version="1.6" metadata-complete="true">
+
+  <description>LocalTransaction JDBC Wrapper Resource Adapter</description>
+  <display-name>LocalTransaction JDBC Wrapper</display-name>
+  
+  <vendor-name>Red Hat Inc</vendor-name>
+  <eis-type>JDBC 4.x Relational Database</eis-type>
+  <resourceadapter-version>8.0</resourceadapter-version>
+  
+  <license>
+    <description>
+IronJacamar, a Java EE Connector Architecture implementation
+Copyright 2014, Red Hat Inc, and individual contributors
+as indicated by the @author tags. See the copyright.txt file in the
+distribution for a full listing of individual contributors.
+
+This is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this software; if not, write to the Free
+Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301 USA, or see the FSF site: http://www.fsf.org.
+    </description>
+    <license-required>true</license-required>
+  </license>
+   
+  <resourceadapter>
+    <resourceadapter-class>org.jboss.jca.adapters.jdbc.JDBCResourceAdapter</resourceadapter-class>
+    <outbound-resourceadapter>
+      <connection-definition>
+        <managedconnectionfactory-class>org.jboss.jca.adapters.jdbc.local.LocalManagedConnectionFactory</managedconnectionfactory-class>
+        <config-property>
+          <description>The jdbc driver class.</description>
+          <config-property-name>DriverClass</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The jdbc datasource class.</description>
+          <config-property-name>DataSourceClass</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The jdbc connection url class.</description>
+          <config-property-name>ConnectionURL</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The jdbc connection url delimeter.</description>
+          <config-property-name>URLDelimiter</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The configurable URLSelectorStrategy class name.</description>
+          <config-property-name>UrlSelectorStrategyClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The default transaction isolation of the connections.</description>
+          <config-property-name>TransactionIsolation</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The number of cached prepared statements per connection.</description>
+          <config-property-name>PreparedStatementCacheSize</config-property-name>
+          <config-property-type>java.lang.Integer</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Whether to share prepared statements.</description>
+          <config-property-name>SharePreparedStatements</config-property-name>
+          <config-property-type>java.lang.Boolean</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The user name to connect to the database.</description>
+          <config-property-name>UserName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The password to connect to the database.</description>
+          <config-property-name>Password</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Connection properties for the database.</description>
+          <config-property-name>ConnectionProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>An SQL statement to be executed when a new connection is created as auxillary setup.</description>
+          <config-property-name>NewConnectionSQL</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>An SQL statement that may be executed when a managed connection is taken out of the pool and is about to be given to a client: the purpose is to verify that the connection still works.</description>
+          <config-property-name>CheckValidConnectionSQL</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The fully qualified name of a class implementing org.jboss.jca.adapters.jdbc.ValidConnectionChecker that can determine for a particular vender db when a connection is valid.</description>
+          <config-property-name>ValidConnectionCheckerClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>TThe properties to inect into class implementing org.jboss.jca.adapters.jdbc.ValidConnectionChecker that can determine for a particular vender db when a connection is valid.</description>
+          <config-property-name>ValidConnectionCheckerProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The fully qualified name of a class implementing org.jboss.jca.adapters.jdbc.ExceptionSorter that can determine for a particular vender db which exceptions are fatal and mean a connection should be discarded.</description>
+          <config-property-name>ExceptionSorterClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The properties to inect into class implementing org.jboss.jca.adapters.jdbc.ExceptionSorter that can determine for a particular vender db which exceptions are fatal and mean a connection should be discarded.</description>
+          <config-property-name>ExceptionSorterProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The fully qualified name of a class implementing org.jboss.jca.adapters.jdbc.StaleConnectionChecker that can determine for a particular vender db when a connection is stale.</description>
+          <config-property-name>StaleConnectionCheckerClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The properties to inect into class implementing org.jboss.jca.adapters.jdbc.StaleConnectionChecker that can determine for a particular vender db when a connection is stale.</description>
+          <config-property-name>StaleConnectionCheckerProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property> 		
+        <config-property>
+          <description>Whether to track unclosed statements - false/true/nowarn</description>
+          <config-property-name>TrackStatements</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Whether to set the query timeout based on the transaction timeout</description>
+          <config-property-name>TransactionQueryTimeout</config-property-name>
+          <config-property-type>java.lang.Boolean</config-property-type>
+        </config-property>
+        <config-property>
+          <description>A configured query timeout</description>
+          <config-property-name>QueryTimeout</config-property-name>
+          <config-property-type>java.lang.Integer</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Maximum wait for a lock</description>
+          <config-property-name>UseTryLock</config-property-name>
+          <config-property-type>java.lang.Integer</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Enable spy functionality</description>
+          <config-property-name>Spy</config-property-name>
+          <config-property-type>java.lang.Boolean</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The JNDI name of the datasource</description>
+          <config-property-name>JndiName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <connectionfactory-interface>javax.sql.DataSource</connectionfactory-interface>
+        <connectionfactory-impl-class>org.jboss.jca.adapters.jdbc.WrapperDataSource</connectionfactory-impl-class>
+        <connection-interface>java.sql.Connection</connection-interface>
+        <connection-impl-class>org.jboss.jca.adapters.jdbc.WrappedConnection</connection-impl-class>
+      </connection-definition>
+      <transaction-support>LocalTransaction</transaction-support>
+      <authentication-mechanism>
+        <authentication-mechanism-type>BasicPassword</authentication-mechanism-type>
+        <credential-interface>javax.resource.spi.security.PasswordCredential</credential-interface>
+      </authentication-mechanism>
+      <reauthentication-support>false</reauthentication-support>
+    </outbound-resourceadapter>
+  </resourceadapter>
+</connector>

--- a/common/src/main/resources/jdbc-xa-ra.xml
+++ b/common/src/main/resources/jdbc-xa-ra.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<connector xmlns="http://java.sun.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+           http://java.sun.com/xml/ns/j2ee/connector_1_6.xsd"
+           version="1.6" metadata-complete="true">
+  
+  <description>Resource Adapter for JDBC 4 XA drivers</description>
+  <display-name>JDBC XATransaction ResourceAdapter</display-name>
+  
+  <vendor-name>Red Hat Inc</vendor-name>
+  <eis-type>JDBC 4.x XA Relational Database</eis-type>
+  <resourceadapter-version>8.0</resourceadapter-version>
+   
+  <license>
+    <description>
+IronJacamar, a Java EE Connector Architecture implementation
+Copyright 2014, Red Hat Inc, and individual contributors
+as indicated by the @author tags. See the copyright.txt file in the
+distribution for a full listing of individual contributors.
+
+This is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this software; if not, write to the Free
+Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301 USA, or see the FSF site: http://www.fsf.org.
+    </description>
+    <license-required>true</license-required>
+  </license>
+   
+  <resourceadapter>
+    <resourceadapter-class>org.jboss.jca.adapters.jdbc.JDBCResourceAdapter</resourceadapter-class>
+    <outbound-resourceadapter>
+      <connection-definition>
+        <managedconnectionfactory-class>org.jboss.jca.adapters.jdbc.xa.XAManagedConnectionFactory</managedconnectionfactory-class>
+        <config-property>
+          <description>The default user name used to create JDBC connections.</description>
+          <config-property-name>UserName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The default password used to create JDBC connections.</description>
+          <config-property-name>Password</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The properties to set up the XA driver. These properties must be in the form name1=value1;name2=value2;...namen=valuen</description>
+          <config-property-name>XADataSourceProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The jdbc connection url delimeter.</description>
+          <config-property-name>URLDelimiter</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The property that contains the list of URLs.</description>
+          <config-property-name>URLProperty</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The configurable URLSelectorStrategy class name.</description>
+          <config-property-name>UrlSelectorStrategyClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The class name of the JDBC XA driver that handlesthis JDBC URL.</description>
+          <config-property-name>XADataSourceClass</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The transaction isolation for new connections. Not necessary: the driver default will be used if ommitted.</description>
+          <config-property-name>TransactionIsolation</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The number of cached prepared statements per connection.</description>
+          <config-property-name>PreparedStatementCacheSize</config-property-name>
+          <config-property-type>java.lang.Integer</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Whether to share prepared statements.</description>
+          <config-property-name>SharePreparedStatements</config-property-name>
+          <config-property-type>java.lang.Boolean</config-property-type>
+        </config-property>
+        <config-property>
+          <description>An SQL statement to be executed when a new connection is created as auxillary setup.</description>
+          <config-property-name>NewConnectionSQL</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>An SQL statement that may be executed when a managed connection is taken out of the pool and is about to be given to a client: the purpose is to verify that the connection still works.</description>
+          <config-property-name>CheckValidConnectionSQL</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The fully qualified name of a class implementing org.jboss.jca.adapters.jdbc.ValidConnectionChecker that can determine for a particular vender db when a connection is valid.</description>
+          <config-property-name>ValidConnectionCheckerClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>TThe properties to inect into class implementing org.jboss.jca.adapters.jdbc.ValidConnectionChecker that can determine for a particular vender db when a connection is valid.</description>
+          <config-property-name>ValidConnectionCheckerProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The fully qualified name of a class implementing org.jboss.jca.adapters.jdbc.ExceptionSorter that can determine for a particular vender db which exceptions are fatal and mean a connection should be discarded.</description>
+          <config-property-name>ExceptionSorterClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The properties to inect into class implementing org.jboss.jca.adapters.jdbc.ExceptionSorter that can determine for a particular vender db which exceptions are fatal and mean a connection should be discarded.</description>
+          <config-property-name>ExceptionSorterProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The fully qualified name of a class implementing org.jboss.jca.adapters.jdbc.StaleConnectionChecker that can determine for a particular vender db when a connection is stale.</description>
+          <config-property-name>StaleConnectionCheckerClassName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The properties to inect into class implementing org.jboss.jca.adapters.jdbc.StaleConnectionChecker that can determine for a particular vender db when a connection is stale.</description>
+          <config-property-name>StaleConnectionCheckerProperties</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>       	
+        <config-property>
+          <description>Whether to track unclosed statements - false/true/nowarn</description>
+          <config-property-name>TrackStatements</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Whether to set the query timeout based on the transaction timeout</description>
+          <config-property-name>TransactionQueryTimeout</config-property-name>
+          <config-property-type>java.lang.Boolean</config-property-type>
+        </config-property>
+        <config-property>
+          <description>A configured query timeout</description>
+          <config-property-name>QueryTimeout</config-property-name>
+          <config-property-type>java.lang.Integer</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Maximum wait for a lock</description>
+          <config-property-name>UseTryLock</config-property-name>
+          <config-property-type>java.lang.Integer</config-property-type>
+        </config-property>
+        <config-property>
+          <description>Enable spy functionality</description>
+          <config-property-name>Spy</config-property-name>
+          <config-property-type>java.lang.Boolean</config-property-type>
+        </config-property>
+        <config-property>
+          <description>The JNDI name of the datasource</description>
+          <config-property-name>JndiName</config-property-name>
+          <config-property-type>java.lang.String</config-property-type>
+        </config-property>
+        <connectionfactory-interface>javax.sql.DataSource</connectionfactory-interface>
+        <connectionfactory-impl-class>org.jboss.jca.adapters.jdbc.WrapperDataSource</connectionfactory-impl-class>
+        <connection-interface>java.sql.Connection</connection-interface>
+        <connection-impl-class>org.jboss.jca.adapters.jdbc.WrappedConnection</connection-impl-class>
+      </connection-definition>
+      <transaction-support>XATransaction</transaction-support>
+      <authentication-mechanism>
+        <authentication-mechanism-type>BasicPassword</authentication-mechanism-type>
+        <credential-interface>javax.resource.spi.security.PasswordCredential</credential-interface>
+      </authentication-mechanism>
+      <reauthentication-support>false</reauthentication-support>
+    </outbound-resourceadapter>
+  </resourceadapter>
+</connector>

--- a/common/src/test/java/com.kumuluz.ee.common.jca/DriverInfoTest.java
+++ b/common/src/test/java/com.kumuluz.ee.common.jca/DriverInfoTest.java
@@ -1,0 +1,139 @@
+package com.kumuluz.ee.common.jca;
+
+import com.kumuluz.ee.common.jca.drivers.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class DriverInfoTest {
+
+    private DriverInfo findByUrl(String url) {
+        Optional<DriverInfo> driver = DriverInfo.fromJdbcUrl(url);
+        return (driver.isPresent() ? driver.get() : null);
+    }
+
+    private DriverInfo findByXaDsClass(String xaDsClass) {
+        Optional<DriverInfo> driver = DriverInfo.fromXaDataSourceClass(xaDsClass);
+        return (driver.isPresent() ? driver.get() : null);
+    }
+
+    private void assertDriverInfo(Class<?> expected, DriverInfo actual) {
+        Assert.assertNotNull("DriverInfo not found", actual);
+
+        Assert.assertEquals(expected.getName(), actual.getClass().getName());
+    }
+
+    @Test
+    public void db2DriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:db2:ibmdb2db");
+        assertDriverInfo(DB2DriverInfo.class, driver);
+    }
+
+    @Test
+    public void db2DriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("com.ibm.db2.jdbc.DB2XADataSource");
+        assertDriverInfo(DB2DriverInfo.class, driver);
+    }
+
+    @Test
+    public void derbyDriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:derby://localhost:1527/db");
+        assertDriverInfo(DerbyDriverInfo.class, driver);
+    }
+
+    @Test
+    public void derbyDriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("org.apache.derby.jdbc.ClientXADataSource");
+        assertDriverInfo(DerbyDriverInfo.class, driver);
+    }
+
+    @Test
+    public void h2DriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        assertDriverInfo(H2DriverInfo.class, driver);
+    }
+
+    @Test
+    public void h2DriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("org.h2.jdbcx.JdbcDataSource");
+        assertDriverInfo(H2DriverInfo.class, driver);
+    }
+
+    @Test
+    public void mariaDbDriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:mariadb://localhost:3306/test");
+        assertDriverInfo(MariaDBDriverInfo.class, driver);
+    }
+
+    @Test
+    public void mariaDbDriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("org.mariadb.jdbc.MariaDbDataSource");
+        assertDriverInfo(MariaDBDriverInfo.class, driver);
+    }
+
+    @Test
+    public void mySqlDriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:mysql://localhost:3306/test");
+        assertDriverInfo(MySQLDriverInfo.class, driver);
+    }
+
+    @Test
+    public void mySqlDriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("com.mysql.jdbc.jdbc2.optional.MysqlXADataSource");
+        assertDriverInfo(MySQLDriverInfo.class, driver);
+    }
+
+    @Test
+    public void oracleDriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:oracle:thin:@localhost:1521:test");
+        assertDriverInfo(OracleDriverInfo.class, driver);
+    }
+
+    @Test
+    public void oracleDriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("oracle.jdbc.xa.client.OracleXADataSource");
+        assertDriverInfo(OracleDriverInfo.class, driver);
+    }
+
+    @Test
+    public void postgresDriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:postgresql://localhost:5432/test");
+        assertDriverInfo(PostgreSQLDriverInfo.class, driver);
+    }
+
+    @Test
+    public void postgresDriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("org.postgresql.xa.PGXADataSource");
+        assertDriverInfo(PostgreSQLDriverInfo.class, driver);
+    }
+
+    @Test
+    public void sqlServerDriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:sqlserver://localhost:1433;DatabaseName=test");
+        assertDriverInfo(SQLServerDriverInfo.class, driver);
+    }
+
+    @Test
+    public void sqlServerDriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("com.microsoft.sqlserver.jdbc.SQLServerXADataSource");
+        assertDriverInfo(SQLServerDriverInfo.class, driver);
+    }
+
+    @Test
+    public void sybaseDriverByUrl() {
+        DriverInfo driver = findByUrl("jdbc:sybase:Tds:localhost:2638/TEST");
+        assertDriverInfo(SybaseDriverInfo.class, driver);
+    }
+
+    @Test
+    public void sybaseDriverByXaClass() {
+        DriverInfo driver = findByXaDsClass("com.sybase.jdbc4.jdbc.SybXADataSource");
+        assertDriverInfo(SybaseDriverInfo.class, driver);
+    }
+
+}

--- a/components/jpa/eclipselink/src/main/java/com/kumuluz/ee/jpa/eclipselink/KumuluzPlatform.java
+++ b/components/jpa/eclipselink/src/main/java/com/kumuluz/ee/jpa/eclipselink/KumuluzPlatform.java
@@ -22,6 +22,7 @@ package com.kumuluz.ee.jpa.eclipselink;
 
 import org.eclipse.persistence.platform.server.ServerPlatformBase;
 import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.JNDIConnector;
 
 /**
  * @author Marcos Koch Salvador
@@ -36,6 +37,11 @@ public class KumuluzPlatform extends ServerPlatformBase {
     @Override
     public Class<?> getExternalTransactionControllerClass() {
         return KumuluzTransactionController.class;
+    }
+
+    @Override
+    public int getJNDIConnectorLookupType() {
+        return JNDIConnector.STRING_LOOKUP;
     }
 
 }

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/datasources/JtaXAConnectionWrapper.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/datasources/JtaXAConnectionWrapper.java
@@ -38,6 +38,7 @@ import java.util.logging.Logger;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public class JtaXAConnectionWrapper implements Connection {
 
     private Logger log = Logger.getLogger(JtaXAConnectionWrapper.class.getSimpleName());

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/datasources/JtaXADataSourceWrapper.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/datasources/JtaXADataSourceWrapper.java
@@ -31,6 +31,7 @@ import java.sql.SQLException;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public class JtaXADataSourceWrapper extends NonJtaXADataSourceWrapper {
 
     public JtaXADataSourceWrapper(XADataSource xaDataSource) {

--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/datasources/XAStatementProxy.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/datasources/XAStatementProxy.java
@@ -32,6 +32,7 @@ import java.sql.Statement;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public class XAStatementProxy implements InvocationHandler {
 
     private Statement statement;

--- a/components/jta/narayana/pom.xml
+++ b/components/jta/narayana/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>narayana-jta</artifactId>
             <version>${narayana.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.jts</groupId>
+            <artifactId>narayana-jts-integration</artifactId>
+            <version>${narayana.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/JtaComponent.java
+++ b/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/JtaComponent.java
@@ -20,18 +20,27 @@
 */
 package com.kumuluz.ee.jta.narayana;
 
-import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.common.*;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jta.utils.JNDIManager;
+import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 import com.kumuluz.ee.common.Component;
 import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.common.dependencies.EeComponentDef;
 import com.kumuluz.ee.common.dependencies.EeComponentType;
+import com.kumuluz.ee.common.exceptions.KumuluzServerException;
+import com.kumuluz.ee.common.utils.StringUtils;
 import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.jta.common.JtaTransactionHolder;
 
 import javax.naming.NamingException;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Marcos Koch Salvador
@@ -41,22 +50,91 @@ import java.util.logging.Logger;
 public class JtaComponent implements Component {
 
     private Logger log = Logger.getLogger(JtaComponent.class.getSimpleName());
+    private NarayanaConfig narayanaConfig;
 
     @Override
     public void init(KumuluzServerWrapper server, EeConfig eeConfig) {
         JtaTransactionHolder.getInstance().setTransactionAcquirer(new NarayanaTransactionAcquirer());
+
+        narayanaConfig = new NarayanaConfig();
+
+        ConfigurationUtil cfg = ConfigurationUtil.getInstance();
+        Optional<String> narayanaJtaOpt = cfg.get("kumuluzee.jta.narayana");
+
+        if (narayanaJtaOpt.isPresent()) {
+
+            Optional<String> nodeIdentifier = cfg.get("kumuluzee.jta.narayana.node-identifier");
+            nodeIdentifier.ifPresent(narayanaConfig::setNodeIdentifier);
+
+            Optional<String> objectStoreDir = cfg.get("kumuluzee.jta.narayana.object-store-dir");
+            objectStoreDir.ifPresent(narayanaConfig::setObjectStoreDir);
+
+            Optional<Boolean> commitOnePhase = cfg.getBoolean("kumuluzee.jta.narayana.commit-one-phase");
+            commitOnePhase.ifPresent(narayanaConfig::setCommitOnePhase);
+
+            Optional<Integer> defaultTimeout = cfg.getInteger("kumuluzee.jta.narayana.default-timeout");
+            defaultTimeout.ifPresent(narayanaConfig::setDefaultTimeout);
+
+            Optional<Integer> periodicRecoveryPeriod = cfg.getInteger("kumuluzee.jta.narayana.periodic-recovery-period");
+            periodicRecoveryPeriod.ifPresent(narayanaConfig::setPeriodicRecoveryPeriod);
+
+            Optional<Integer> recoveryBackoffPeriod = cfg.getInteger("kumuluzee.jta.narayana.recovery-backoff-period");
+            recoveryBackoffPeriod.ifPresent(narayanaConfig::setRecoveryBackoffPeriod);
+
+            Optional<String> orphanFilters = cfg.get("kumuluzee.jta.narayana.orphan-filters");
+            orphanFilters.ifPresent(v -> narayanaConfig.setOrphanFilters( StringUtils.splitToList(v, ",") ));
+
+            Optional<String> recoveryModules = cfg.get("kumuluzee.jta.narayana.recovery-modules");
+            recoveryModules.ifPresent(v -> narayanaConfig.setRecoveryModules( StringUtils.splitToList(v, ",") ));
+
+            Optional<String> expiryScanners = cfg.get("kumuluzee.jta.narayana.expiry-scanners");
+            expiryScanners.ifPresent(v -> narayanaConfig.setExpiryScanners( StringUtils.splitToList(v, ",") ));
+        }
     }
 
     @Override
     public void load() {
-        log.info("Initiating Narayana JTA");
-
-        arjPropertyManager.getObjectStoreEnvironmentBean().setObjectStoreDir("ObjectStore");
-
         try {
+            log.info("Setuping Narayana JTA");
+
+            getPopulator(CoreEnvironmentBean.class).setNodeIdentifier(narayanaConfig.getNodeIdentifier());
+
+            setObjectStoreDir(narayanaConfig.getObjectStoreDir());
+
+            getPopulator(CoordinatorEnvironmentBean.class).setCommitOnePhase(narayanaConfig.isCommitOnePhase());
+
+            getPopulator(CoordinatorEnvironmentBean.class).setDefaultTimeout(narayanaConfig.getDefaultTimeout());
+
+            getPopulator(RecoveryEnvironmentBean.class).setPeriodicRecoveryPeriod(narayanaConfig.getPeriodicRecoveryPeriod());
+
+            getPopulator(RecoveryEnvironmentBean.class).setRecoveryBackoffPeriod(narayanaConfig.getRecoveryBackoffPeriod());
+
+            getPopulator(JTAEnvironmentBean.class).setXaResourceOrphanFilterClassNames(narayanaConfig.getOrphanFilters());
+
+            getPopulator(RecoveryEnvironmentBean.class).setRecoveryModuleClassNames(narayanaConfig.getRecoveryModules());
+
+            getPopulator(RecoveryEnvironmentBean.class).setExpiryScannerClassNames(narayanaConfig.getExpiryScanners());
+
             JNDIManager.bindJTAImplementation();
-        } catch (NamingException e) {
-            log.log(Level.WARNING, e.getMessage(), e);
+        }  catch (Exception e) {
+            throw new KumuluzServerException("There was an error while configuring Narayana", e);
         }
+    }
+
+    private void setObjectStoreDir(String objectStoreDir) {
+        if (Objects.isNull(objectStoreDir)) {
+            return;
+        }
+        getPopulator(ObjectStoreEnvironmentBean.class).setObjectStoreDir(objectStoreDir);
+        getPopulator(ObjectStoreEnvironmentBean.class, "communicationStore").setObjectStoreDir(objectStoreDir);
+        getPopulator(ObjectStoreEnvironmentBean.class, "stateStore").setObjectStoreDir(objectStoreDir);
+    }
+
+    private <T> T getPopulator(Class<T> beanClass) {
+        return BeanPopulator.getDefaultInstance(beanClass);
+    }
+
+    private <T> T getPopulator(Class<T> beanClass, String name) {
+        return BeanPopulator.getNamedInstance(beanClass, name);
     }
 }

--- a/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaConfig.java
+++ b/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaConfig.java
@@ -1,0 +1,149 @@
+package com.kumuluz.ee.jta.narayana;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Marcos Koch Salvador
+ * @since 2.4.0
+ */
+public class NarayanaConfig {
+
+    /**
+     * Unique transaction manager id.
+     */
+    private String nodeIdentifier = "1";
+
+    /**
+     * Transaction object store directory.
+     */
+    private String objectStoreDir = "tx-object-store";
+
+    /**
+     * Enable one phase commit optimization.
+     */
+    private boolean commitOnePhase = true;
+
+    /**
+     * Transaction timeout in seconds.
+     */
+    private int defaultTimeout = 60;
+
+    /**
+     * Interval in which periodic recovery scans are performed in seconds.
+     */
+    private int periodicRecoveryPeriod = 120;
+
+    /**
+     * Back off period between first and second phases of the recovery scan in seconds.
+     */
+    private int recoveryBackoffPeriod = 10;
+
+    /**
+     * List of orphan filters.
+     */
+    private List<String> orphanFilters = Arrays.asList(
+        "com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter",
+        "com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter"
+    );
+
+    /**
+     * List of recovery modules.
+     */
+    private List<String> recoveryModules = Arrays.asList(
+        "com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule",
+        "com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule"
+    );
+
+    /**
+     * List of expiry scanners.
+     */
+    private List<String> expiryScanners = Arrays.asList(
+        "com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule",
+        "com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule"
+    );
+
+    public String getNodeIdentifier() {
+        return nodeIdentifier;
+    }
+
+    public void setNodeIdentifier(String nodeIdentifier) {
+        this.nodeIdentifier = nodeIdentifier;
+    }
+
+    public String getObjectStoreDir() {
+        return objectStoreDir;
+    }
+
+    public void setObjectStoreDir(String objectStoreDir) {
+        this.objectStoreDir = objectStoreDir;
+    }
+
+    public boolean isCommitOnePhase() {
+        return commitOnePhase;
+    }
+
+    public void setCommitOnePhase(boolean commitOnePhase) {
+        this.commitOnePhase = commitOnePhase;
+    }
+
+    public int getDefaultTimeout() {
+        return defaultTimeout;
+    }
+
+    public void setDefaultTimeout(int defaultTimeout) {
+        this.defaultTimeout = defaultTimeout;
+    }
+
+    public int getPeriodicRecoveryPeriod() {
+        return periodicRecoveryPeriod;
+    }
+
+    public void setPeriodicRecoveryPeriod(int periodicRecoveryPeriod) {
+        this.periodicRecoveryPeriod = periodicRecoveryPeriod;
+    }
+
+    public int getRecoveryBackoffPeriod() {
+        return recoveryBackoffPeriod;
+    }
+
+    public void setRecoveryBackoffPeriod(int recoveryBackoffPeriod) {
+        this.recoveryBackoffPeriod = recoveryBackoffPeriod;
+    }
+
+    public List<String> getOrphanFilters() {
+        if (Objects.isNull(orphanFilters)) {
+            orphanFilters = Collections.emptyList();
+        }
+        return orphanFilters;
+    }
+
+    public void setOrphanFilters(List<String> orphanFilters) {
+        this.orphanFilters = orphanFilters;
+    }
+
+    public List<String> getRecoveryModules() {
+        if (Objects.isNull(recoveryModules)) {
+            recoveryModules = Collections.emptyList();
+        }
+        return recoveryModules;
+    }
+
+    public void setRecoveryModules(List<String> recoveryModules) {
+        this.recoveryModules = recoveryModules;
+    }
+
+    public List<String> getExpiryScanners() {
+        if (Objects.isNull(expiryScanners)) {
+            expiryScanners = Collections.emptyList();
+        }
+        return expiryScanners;
+    }
+
+    public void setExpiryScanners(List<String> expiryScanners) {
+        this.expiryScanners = expiryScanners;
+    }
+
+}

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -103,14 +103,30 @@ public class EeConfigFactory {
                 Optional<String> conUrl = cfg.get("kumuluzee.datasources[" + i + "].connection-url");
                 Optional<String> user = cfg.get("kumuluzee.datasources[" + i + "].username");
                 Optional<String> pass = cfg.get("kumuluzee.datasources[" + i + "].password");
+
+                Optional<Integer> initialPool = cfg.getInteger("kumuluzee.datasources[" + i + "].initial-pool-size");
+                Optional<Integer> minPool = cfg.getInteger("kumuluzee.datasources[" + i + "].min-pool-size");
                 Optional<Integer> maxPool = cfg.getInteger("kumuluzee.datasources[" + i + "].max-pool-size");
+
+                Optional<String> checkConnectionSql = cfg.get("kumuluzee.datasources[" + i + "].check-connection-sql");
+
+                Optional<Integer> blockingTimeoutMillis = cfg.getInteger("kumuluzee.datasources[" + i + "].blocking-timeout-millis");
+                Optional<Integer> idleTimeoutMinutes = cfg.getInteger("kumuluzee.datasources[" + i + "].idle-timeout-minutes");
 
                 jndiName.ifPresent(dsc::jndiName);
                 driverClass.ifPresent(dsc::driverClass);
                 conUrl.ifPresent(dsc::connectionUrl);
                 user.ifPresent(dsc::username);
                 pass.ifPresent(dsc::password);
+
+                initialPool.ifPresent(dsc::initialPoolSize);
+                minPool.ifPresent(dsc::minPoolSize);
                 maxPool.ifPresent(dsc::maxPoolSize);
+
+                checkConnectionSql.ifPresent(dsc::checkConnectionSql);
+
+                blockingTimeoutMillis.ifPresent(dsc::blockingTimeoutMillis);
+                idleTimeoutMinutes.ifPresent(dsc::idleTimeoutMinutes);
 
                 eeConfigBuilder.datasource(dsc);
             }
@@ -142,9 +158,27 @@ public class EeConfigFactory {
 
                         Optional<String> propValue = cfg.get("kumuluzee.xa-datasources[" + i + "].props." + propName);
 
-                        propValue.ifPresent(v -> xdsc.prop(StringUtils.hyphenCaseToCamelCase(propName), v));
+                        propValue.ifPresent(v -> xdsc.prop(StringUtils.hyphenCaseToUpperCamelCase(propName), v));
                     }
                 }
+
+                Optional<Integer> initialPool = cfg.getInteger("kumuluzee.xa-datasources[" + i + "].initial-pool-size");
+                Optional<Integer> minPool = cfg.getInteger("kumuluzee.xa-datasources[" + i + "].min-pool-size");
+                Optional<Integer> maxPool = cfg.getInteger("kumuluzee.xa-datasources[" + i + "].max-pool-size");
+
+                Optional<String> checkConnectionSql = cfg.get("kumuluzee.xa-datasources[" + i + "].check-connection-sql");
+
+                Optional<Integer> blockingTimeoutMillis = cfg.getInteger("kumuluzee.xa-datasources[" + i + "].blocking-timeout-millis");
+                Optional<Integer> idleTimeoutMinutes = cfg.getInteger("kumuluzee.xa-datasources[" + i + "].idle-timeout-minutes");
+
+                initialPool.ifPresent(xdsc::initialPoolSize);
+                minPool.ifPresent(xdsc::minPoolSize);
+                maxPool.ifPresent(xdsc::maxPoolSize);
+
+                checkConnectionSql.ifPresent(xdsc::checkConnectionSql);
+
+                blockingTimeoutMillis.ifPresent(xdsc::blockingTimeoutMillis);
+                idleTimeoutMinutes.ifPresent(xdsc::idleTimeoutMinutes);
 
                 eeConfigBuilder.xaDatasource(xdsc);
             }

--- a/core/src/main/java/com/kumuluz/ee/factories/JtaXADataSourceFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/JtaXADataSourceFactory.java
@@ -29,6 +29,7 @@ import javax.sql.XADataSource;
  * @author Tilen Faganel
  * @since 2.3.0
  */
+@Deprecated
 public class JtaXADataSourceFactory {
 
     public static NonJtaXADataSourceWrapper buildJtaXADataSourceWrapper(XADataSource xaDataSource) {

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,16 @@
         <jta.version>1.2</jta.version>
 
         <jandex.version>2.0.3.Final</jandex.version>
-        <hikari.version>2.6.1</hikari.version>
         <yamlbeans.version>1.11</yamlbeans.version>
         <yaml.version>1.18</yaml.version>
         <junit.version>4.12</junit.version>
+
+        <fungal.version>0.11.0.Final</fungal.version>
+        <ironjacamar.version>1.4.5.Final</ironjacamar.version>
+        <shrinkwrap.version>1.2.0</shrinkwrap.version>
+        <shrinkwrap-descriptors.version>2.0.0</shrinkwrap-descriptors.version>
+        <jnpserver.version>5.0.5.Final</jnpserver.version>
+        <jboss-common-core.version>2.5.0.Final</jboss-common-core.version>
 
         <uel-version>3.0.0</uel-version>
         <weld.version>2.4.3.Final</weld.version>
@@ -101,6 +107,17 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>jboss</id>
+            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+        </repository>
+        <repository>
+            <id>fungal</id>
+            <url>http://jesperpedersen.github.com/fungal/maven2</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -366,11 +383,6 @@
                 <groupId>org.jboss</groupId>
                 <artifactId>jandex</artifactId>
                 <version>${jandex.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP</artifactId>
-                <version>${hikari.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
As I commented in issue #41, here is my code integration of KumuluzEE with IronJacamar. It’s capable to replacing HikariCP, providing DataSources for Local and XA JDBC connections.

I put all my implementation into "kumuluz-common" module because it is used by other Kumuluz's modules and also because the HikariCP dependency was there.

When declaring the IronJacamar's dependencies, I discovered that three of them weren't avaliable on default Maven repository. To include them in the project, I needed to reference these additional repositories in the pom.xml (at the project's root) and configure the pom.xml of "kumuluz-common" to embed these dependencies into the JAR itself. Sorry for this approach, I couldn’t think in anything better.

IronJcamar has two Resource Adapters to provide DataSources: [jdbc-local.rar](https://mvnrepository.com/artifact/org.jboss.ironjacamar/jdbc-local/1.4.5.Final) and [jdbc-xa.rar](https://mvnrepository.com/artifact/org.jboss.ironjacamar/jdbc-xa/1.4.5.Final). However, I couldn't do IronJacamar loads them as Maven dependency during Kumuluz's bootstrap. To overcome this difficulty, I create the ResourceAdapterHelp class who builds theses \*.rar files through ShrinkWrap (it's in IronJacamar's dependencies).
**Suggestion**: In the last days, I realized that you are working in a Maven plugin to build a UberJAR with the necessary depedencies and structure to the microservice work correctly. It would be very interesting if this plugin also copies all the Resource Adapters (\*.rar files) into UberJAR and tells Kumuluz which RAR files the IronJacamar should load.

To create datasources, HikariCP allows the "driver-class" property to be omitted, however, IronJacamar requires the "driver-class" and "connection-url" properties. To overcome this situation, I created the DriverInfo class. It contains information inherent to the JDBC driver such as: Driver class, XaDataSource class and a query to validate pool connections. I have already implemented a subclass of DriverInfo for the most popular JDBC drivers (DB2, Derby, H2, MariaDB, MySQL, Oracle, PostgreSQL, SQLServer and Sybase).
**NOTE**: Kumuluz keeps running even if an unknown JDBC driver is used. IronJacamar will throw an exception on the console only if the "connection-url" and "driver-class" properties aren't provided.

After these changes, some classes previously created to integrate the XA datasources with the JTA are no longer required. I did not remove them, though, I annotated with @Deprecated to simplify the code review.

As @MBJuric requested, I include KumuluzEE Config support to configure some datasources properties. I have listed below all the options that I include. If I have forgotten any, in this [link](http://www.ironjacamar.org/doc/userguide/1.2/en-US/html/ch05.html#d0e2688) are available all the properties provided by IronJacamar.
**NOTE**: Except for "check-connection-sql", all properties follow the default value set by IronJacamar. This information is also available in the link I just mentioned.

```
kumuluzee.datasources[ i ].initial-pool-size
kumuluzee.datasources[ i ].min-pool-size
kumuluzee.datasources[ i ].max-pool-size
kumuluzee.datasources[ i ].check-connection-sql
kumuluzee.datasources[ i ].blocking-timeout-millis
kumuluzee.datasources[ i ].idle-timeout-minutes

kumuluzee.xa-datasources[ i ].initial-pool-size
kumuluzee.xa-datasources[ i ].min-pool-size
kumuluzee.xa-datasources[ i ].max-pool-size
kumuluzee.xa-datasources[ i ].check-connection-sql
kumuluzee.xa-datasources[ i ].blocking-timeout-millis
kumuluzee.xa-datasources[ i ].idle-timeout-minutes
```

Continuing with KumuluzEE Config, I also added support to some Narayana JTA properties:
```
kumuluzee.jta.narayana.node-identifier
kumuluzee.jta.narayana.object-store-dir
kumuluzee.jta.narayana.commit-one-phase
kumuluzee.jta.narayana.default-timeout
kumuluzee.jta.narayana.periodic-recovery-period
kumuluzee.jta.narayana.recovery-backoff-period
kumuluzee.jta.narayana.orphan-filters
kumuluzee.jta.narayana.recovery-modules
kumuluzee.jta.narayana.expiry-scanners
```

Finally, that's all I've implemented. I hope this is useful to the KumuluzEE project. If anything about my implementation was not clear, feel free to ask.

Marcos