### PR TITLE
Correctly load ConfigExtensions

### DIFF
--- a/core/src/main/java/com/kumuluz/ee/EeApplication.java
+++ b/core/src/main/java/com/kumuluz/ee/EeApplication.java
@@ -213,8 +213,10 @@ public class EeApplication {
             }
 
             for (ConfigurationSource source : sources) {
-                source.init(configImpl.getDispatcher());
-                configImpl.getConfigurationSources().add(source);
+                if (source != null) {
+                    source.init(configImpl.getDispatcher());
+                    configImpl.getConfigurationSources().add(source);
+                }
             }
         }
 


### PR DESCRIPTION
Fixed NullPointerException when processing ConfigExtension with no ConfigurationSources