### PR TITLE
Missing config methods

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
@@ -23,8 +23,8 @@ package com.kumuluz.ee.configuration.sources;
 import com.kumuluz.ee.configuration.ConfigurationSource;
 import com.kumuluz.ee.configuration.utils.ConfigurationDispatcher;
 
-import java.util.*;
-import java.util.logging.Logger;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Tilen Faganel

--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
@@ -124,21 +124,31 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
     @Override
     public Optional<Integer> getListSize(String key) {
 
-        int listSize = -1;
-        int index = -1;
-        String value;
+        key = parseKeyNameForEnvironmentVariables(key);
 
-        do {
-            listSize += 1;
-            index += 1;
-            value = System.getenv(parseKeyNameForEnvironmentVariables(key + "[" + index + "]"));
-        } while (value != null);
+        Integer maxIndex = -1;
 
-        if (listSize > 0) {
-            return Optional.of(listSize);
-        } else {
-            return Optional.empty();
+        for (String envName : System.getenv().keySet()) {
+            if (envName.startsWith(key)) {
+                int openingIndex = key.length();
+                int closingIndex = envName.indexOf("_", openingIndex + 1);
+                if (closingIndex < 0) {
+                    closingIndex = envName.length();
+                }
+
+                try {
+                    Integer idx = Integer.parseInt(envName.substring(openingIndex, closingIndex));
+                    maxIndex = Math.max(maxIndex, idx);
+                } catch (NumberFormatException ignored) {
+                }
+            }
         }
+
+        if (maxIndex != -1) {
+            return Optional.of(maxIndex + 1);
+        }
+
+        return Optional.empty();
     }
 
     @Override

--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/FileConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/FileConfigurationSource.java
@@ -22,6 +22,7 @@ package com.kumuluz.ee.configuration.sources;
 
 import com.kumuluz.ee.configuration.ConfigurationSource;
 import com.kumuluz.ee.configuration.utils.ConfigurationDispatcher;
+import com.kumuluz.ee.configuration.utils.ConfigurationSourceUtils;
 import com.kumuluz.ee.logs.LogDeferrer;
 import org.yaml.snakeyaml.Yaml;
 
@@ -247,24 +248,7 @@ public class FileConfigurationSource implements ConfigurationSource {
                 return Optional.of(((List) value).size());
             }
         } else if (properties != null) {
-            Integer maxIndex = -1;
-
-            for (String propertyName : properties.stringPropertyNames()) {
-                if (propertyName.startsWith(key + "[")) {
-                    int openingIndex = key.length() + 1;
-                    int closingIndex = propertyName.indexOf("]", openingIndex + 1);
-                    try {
-                        Integer idx = Integer.parseInt(propertyName.substring(openingIndex, closingIndex));
-                        maxIndex = Math.max(maxIndex, idx);
-                    } catch (NumberFormatException e) {
-                        log.severe("Cannot cast array index for key: " + propertyName);
-                    }
-                }
-            }
-
-            if (maxIndex != -1) {
-                return Optional.of(maxIndex + 1);
-            }
+            return ConfigurationSourceUtils.getListSize(key, properties.stringPropertyNames());
         }
 
         return Optional.empty();
@@ -290,37 +274,7 @@ public class FileConfigurationSource implements ConfigurationSource {
             return Optional.of(new ArrayList<>(map.keySet()));
 
         } else if (properties != null) {
-            Set<String> mapKeys = new HashSet<>();
-            for (String propertyName : properties.stringPropertyNames()) {
-                String mapKey = "";
-
-                if(propertyName.startsWith(key)) {
-                    int index = key.length() + 1;
-                    if(index < propertyName.length() && propertyName.charAt(index-1) == '.') {
-                        mapKey = propertyName.substring(index);
-                    }
-                }
-
-                if(!mapKey.isEmpty()) {
-                    int endIndex = mapKey.indexOf(".");
-                    if (endIndex > 0) {
-                        mapKey = mapKey.substring(0, endIndex);
-                    }
-
-                    int bracketIndex = mapKey.indexOf("[");
-                    if (bracketIndex > 0) {
-                        mapKey = mapKey.substring(0, bracketIndex);
-                    }
-
-                    mapKeys.add(mapKey);
-                }
-            }
-
-            if (mapKeys.size() == 0) {
-                return Optional.empty();
-            } else {
-                return Optional.of(new ArrayList<>(mapKeys));
-            }
+            return ConfigurationSourceUtils.getMapKeys(key, properties.stringPropertyNames());
         }
 
         return Optional.empty();

--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/SystemPropertyConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/SystemPropertyConfigurationSource.java
@@ -145,9 +145,14 @@ public class SystemPropertyConfigurationSource implements ConfigurationSource {
             }
 
             if(!mapKey.isEmpty()) {
-                int index = mapKey.indexOf(".");
-                if(index > 0) {
-                    mapKey = mapKey.substring(0, index);
+                int endIndex = mapKey.indexOf(".");
+                if(endIndex > 0) {
+                    mapKey = mapKey.substring(0, endIndex);
+                }
+
+                int bracketIndex = mapKey.indexOf("[");
+                if (bracketIndex > 0) {
+                    mapKey = mapKey.substring(0, bracketIndex);
                 }
 
                 mapKeys.add(mapKey);

--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/SystemPropertyConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/SystemPropertyConfigurationSource.java
@@ -22,20 +22,16 @@ package com.kumuluz.ee.configuration.sources;
 
 import com.kumuluz.ee.configuration.ConfigurationSource;
 import com.kumuluz.ee.configuration.utils.ConfigurationDispatcher;
+import com.kumuluz.ee.configuration.utils.ConfigurationSourceUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
-import java.util.logging.Logger;
 
 /**
  * @author Urban Malc
  * @since 2.4.0
  */
 public class SystemPropertyConfigurationSource implements ConfigurationSource {
-
-    private static final Logger log = Logger.getLogger(SystemPropertyConfigurationSource.class.getName());
 
     @Override
     public void init(ConfigurationDispatcher configurationDispatcher) {
@@ -119,64 +115,14 @@ public class SystemPropertyConfigurationSource implements ConfigurationSource {
 
     @Override
     public Optional<Integer> getListSize(String key) {
-        Integer maxIndex = -1;
 
-        for (String propertyName : System.getProperties().stringPropertyNames()) {
-            if (propertyName.startsWith(key + "[")) {
-                int openingIndex = key.length() + 1;
-                int closingIndex = propertyName.indexOf("]", openingIndex + 1);
-                try {
-                    Integer idx = Integer.parseInt(propertyName.substring(openingIndex, closingIndex));
-                    maxIndex = Math.max(maxIndex, idx);
-                } catch (NumberFormatException e) {
-                    log.severe("Cannot cast array index for key: " + propertyName);
-                }
-            }
-        }
-
-        if (maxIndex != -1) {
-            return Optional.of(maxIndex + 1);
-        }
-
-        return Optional.empty();
+        return ConfigurationSourceUtils.getListSize(key, System.getProperties().stringPropertyNames());
     }
 
     @Override
     public Optional<List<String>> getMapKeys(String key) {
 
-        List<String> mapKeys = new ArrayList<>();
-
-        Properties p = System.getProperties();
-        for(String propertyKey : p.stringPropertyNames()) {
-            String mapKey = "";
-
-            if(propertyKey.startsWith(key)) {
-                int index = key.length() + 1;
-                if(index < propertyKey.length() && propertyKey.charAt(index-1) == '.') {
-                    mapKey = propertyKey.substring(index);
-                }
-            }
-
-            if(!mapKey.isEmpty()) {
-                int endIndex = mapKey.indexOf(".");
-                if(endIndex > 0) {
-                    mapKey = mapKey.substring(0, endIndex);
-                }
-
-                int bracketIndex = mapKey.indexOf("[");
-                if (bracketIndex > 0) {
-                    mapKey = mapKey.substring(0, bracketIndex);
-                }
-
-                mapKeys.add(mapKey);
-            }
-        }
-
-        if(mapKeys.isEmpty()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(mapKeys);
+        return ConfigurationSourceUtils.getMapKeys(key, System.getProperties().stringPropertyNames());
     }
 
     @Override

--- a/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationSourceUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationSourceUtils.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+*/
+package com.kumuluz.ee.configuration.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * @author Urban Malc
+ * @since 2.5.0
+ */
+public class ConfigurationSourceUtils {
+
+    private static final Logger log = Logger.getLogger(ConfigurationSourceUtils.class.getName());
+
+    public static Optional<Integer> getListSize(String key, Collection<String> allKeys) {
+        Integer maxIndex = -1;
+
+        for (String propertyKey : allKeys) {
+            if (propertyKey.startsWith(key + "[")) {
+                int openingIndex = key.length() + 1;
+                int closingIndex = propertyKey.indexOf("]", openingIndex + 1);
+                try {
+                    Integer idx = Integer.parseInt(propertyKey.substring(openingIndex, closingIndex));
+                    maxIndex = Math.max(maxIndex, idx);
+                } catch (NumberFormatException e) {
+                    log.severe("Cannot cast array index for key: " + propertyKey);
+                }
+            }
+        }
+
+        if (maxIndex != -1) {
+            return Optional.of(maxIndex + 1);
+        }
+
+        return Optional.empty();
+    }
+
+    public static Optional<List<String>> getMapKeys(String key, Collection<String> allKeys) {
+        List<String> mapKeys = new ArrayList<>();
+
+        for (String propertyKey : allKeys) {
+            String mapKey = "";
+
+            if (propertyKey.startsWith(key)) {
+                int index = key.length() + 1;
+                if (index < propertyKey.length() && propertyKey.charAt(index - 1) == '.') {
+                    mapKey = propertyKey.substring(index);
+                }
+            }
+
+            if (!mapKey.isEmpty()) {
+                int endIndex = mapKey.indexOf(".");
+                if (endIndex > 0) {
+                    mapKey = mapKey.substring(0, endIndex);
+                }
+
+                int bracketIndex = mapKey.indexOf("[");
+                if (bracketIndex > 0) {
+                    mapKey = mapKey.substring(0, bracketIndex);
+                }
+
+                mapKeys.add(mapKey);
+            }
+        }
+
+        if (mapKeys.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(mapKeys);
+    }
+}

--- a/components/cdi/weld/src/main/java/com/kumuluz/ee/configuration/cdi/interceptors/ConfigBundleInterceptor.java
+++ b/components/cdi/weld/src/main/java/com/kumuluz/ee/configuration/cdi/interceptors/ConfigBundleInterceptor.java
@@ -152,8 +152,11 @@ public class ConfigBundleInterceptor {
                     // process list of primitives
                     if (Arrays.asList(primitives).contains(componentType)) {
                         for (int i = 0; i < Array.getLength(array); i++) {
-                            Array.set(array, i, getValueOfPrimitive(componentType, getKeyName(targetClass, method
-                                    .getName(), keyPrefix) + "[" + i + "]").get());
+                            Optional valueOfPrimitive = getValueOfPrimitive(componentType,
+                                    getKeyName(targetClass, method.getName(), keyPrefix) + "[" + i + "]");
+                            if (valueOfPrimitive.isPresent()) {
+                                Array.set(array, i, valueOfPrimitive.get());
+                            }
                         }
 
                         // process list of nested classes


### PR DESCRIPTION
Various bugfixes concerning getMapKeys and getListSize methods.

Changes:
- Implemented getMapKeys and getListSize methods for java properties files.
- Fixed getMapKeys in SystemProperties configuration source - now returns list name instead of every list item
- Changed getListSize behavior in Environment and SystemProperties configuration sources - now returns max index present instead of max consecutive index.

  This enables definitions of arrays across multiple configuration sources. Example:
  config.yml:
  ```yaml
  arr:
    - a
    - b
  ```
  environment variables:
  ```
  ARR2=c
  ARR3=d
  ```
- Added check if Optional present in ConfigBundleInterceptor.java, without which exception would be thrown if list is only partially defined.