### PR TITLE
Fix for uber-jars located in path with lib

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/attributes/ClasspathAttributes.java
+++ b/common/src/main/java/com/kumuluz/ee/common/attributes/ClasspathAttributes.java
@@ -17,7 +17,7 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.common.attributes;
 
 /**
@@ -26,7 +26,7 @@ package com.kumuluz.ee.common.attributes;
  */
 public class ClasspathAttributes {
 
-    public static final String jar = "^((?!lib|/lib).)*$";
+    public static final String jar = "^((?!lib\\_[^\\/]*\\.jar\\.[^\\/]*\\.tmp|/lib\\_[^\\/]*\\.jar\\.[^\\/]*\\.tmp|.*\\/jre\\/lib\\/.*).)*$";
 
     public static final String exploded = ".*/classes/.*";
 


### PR DESCRIPTION
Previous regex pattern for org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern attribute was set to "^((?!lib|/lib).)*$" to skip scanning of jars starting with lib (dependencies) and /lib (jre libs). Regex is now updated to allow uber-jar to be located in path with "/lib/" - fix for #80 .
