### PR TITLE
Fixed the regression of the logging system not initializing correctly on boot

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
@@ -62,6 +62,7 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Integer.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -78,6 +79,7 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Long.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -94,6 +96,7 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Double.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -110,6 +113,7 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Float.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -129,9 +133,12 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
         Integer maxIndex = -1;
 
         for (String envName : System.getenv().keySet()) {
+
             if (envName.startsWith(key)) {
+
                 int openingIndex = key.length();
                 int closingIndex = envName.indexOf("_", openingIndex + 1);
+
                 if (closingIndex < 0) {
                     closingIndex = envName.length();
                 }
@@ -187,7 +194,7 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
 
     private String parseKeyNameForEnvironmentVariables(String key) {
 
-        return key.toUpperCase().replaceAll("\\[", "").replaceAll("\\]", "")
+        return key.toUpperCase().replaceAll("\\[", "").replaceAll("]", "")
                 .replaceAll("-", "").replaceAll("\\.", "_");
 
     }

--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/FileConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/FileConfigurationSource.java
@@ -179,6 +179,7 @@ public class FileConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Integer.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -195,6 +196,7 @@ public class FileConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Long.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -211,6 +213,7 @@ public class FileConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Double.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -227,6 +230,7 @@ public class FileConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Float.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -242,6 +246,7 @@ public class FileConfigurationSource implements ConfigurationSource {
     public Optional<Integer> getListSize(String key) {
 
         if (config != null) {
+
             Object value = getValue(key);
 
             if (value instanceof List) {

--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/SystemPropertyConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/SystemPropertyConfigurationSource.java
@@ -56,6 +56,7 @@ public class SystemPropertyConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Integer.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -72,6 +73,7 @@ public class SystemPropertyConfigurationSource implements ConfigurationSource {
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Long.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -84,9 +86,11 @@ public class SystemPropertyConfigurationSource implements ConfigurationSource {
 
     @Override
     public Optional<Double> getDouble(String key) {
+
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Double.valueOf(value.get()));
             } catch (NumberFormatException e) {
@@ -99,9 +103,11 @@ public class SystemPropertyConfigurationSource implements ConfigurationSource {
 
     @Override
     public Optional<Float> getFloat(String key) {
+
         Optional<String> value = get(key);
 
         if (value.isPresent()) {
+
             try {
                 return Optional.of(Float.valueOf(value.get()));
             } catch (NumberFormatException e) {

--- a/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationSourceUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationSourceUtils.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Logger;
 
 /**
  * @author Urban Malc
@@ -32,20 +31,22 @@ import java.util.logging.Logger;
  */
 public class ConfigurationSourceUtils {
 
-    private static final Logger log = Logger.getLogger(ConfigurationSourceUtils.class.getName());
 
     public static Optional<Integer> getListSize(String key, Collection<String> allKeys) {
+
         Integer maxIndex = -1;
 
         for (String propertyKey : allKeys) {
+
             if (propertyKey.startsWith(key + "[")) {
+
                 int openingIndex = key.length() + 1;
                 int closingIndex = propertyKey.indexOf("]", openingIndex + 1);
+
                 try {
                     Integer idx = Integer.parseInt(propertyKey.substring(openingIndex, closingIndex));
                     maxIndex = Math.max(maxIndex, idx);
-                } catch (NumberFormatException e) {
-                    log.severe("Cannot cast array index for key: " + propertyKey);
+                } catch (NumberFormatException ignored) {
                 }
             }
         }
@@ -58,20 +59,26 @@ public class ConfigurationSourceUtils {
     }
 
     public static Optional<List<String>> getMapKeys(String key, Collection<String> allKeys) {
+
         List<String> mapKeys = new ArrayList<>();
 
         for (String propertyKey : allKeys) {
+
             String mapKey = "";
 
             if (propertyKey.startsWith(key)) {
+
                 int index = key.length() + 1;
+
                 if (index < propertyKey.length() && propertyKey.charAt(index - 1) == '.') {
                     mapKey = propertyKey.substring(index);
                 }
             }
 
             if (!mapKey.isEmpty()) {
+
                 int endIndex = mapKey.indexOf(".");
+
                 if (endIndex > 0) {
                     mapKey = mapKey.substring(0, endIndex);
                 }
@@ -86,6 +93,7 @@ public class ConfigurationSourceUtils {
         }
 
         if (mapKeys.isEmpty()) {
+
             return Optional.empty();
         }
 

--- a/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationUtil.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/utils/ConfigurationUtil.java
@@ -25,7 +25,6 @@ import com.kumuluz.ee.configuration.ConfigurationSource;
 import com.kumuluz.ee.configuration.enums.ConfigurationValueType;
 
 import java.util.*;
-import java.util.logging.Logger;
 
 /**
  * @author Tilen Faganel
@@ -69,7 +68,9 @@ public class ConfigurationUtil {
     public Optional<Boolean> getBoolean(String key) {
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<Boolean> value = configurationSource.getBoolean(key);
+
             if (value.isPresent()) {
                 return value;
             }
@@ -80,7 +81,9 @@ public class ConfigurationUtil {
     public Optional<Integer> getInteger(String key) {
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<Integer> value = configurationSource.getInteger(key);
+
             if (value.isPresent()) {
                 return value;
             }
@@ -91,7 +94,9 @@ public class ConfigurationUtil {
     public Optional<Long> getLong(String key) {
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<Long> value = configurationSource.getLong(key);
+
             if (value.isPresent()) {
                 return value;
             }
@@ -102,7 +107,9 @@ public class ConfigurationUtil {
     public Optional<Double> getDouble(String key) {
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<Double> value = configurationSource.getDouble(key);
+
             if (value.isPresent()) {
                 return value;
             }
@@ -113,7 +120,9 @@ public class ConfigurationUtil {
     public Optional<Float> getFloat(String key) {
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<Float> value = configurationSource.getFloat(key);
+
             if (value.isPresent()) {
                 return value;
             }
@@ -122,10 +131,13 @@ public class ConfigurationUtil {
     }
 
     public Optional<Integer> getListSize(String key) {
+
         int listSize = -1;
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<Integer> currentListSize = configurationSource.getListSize(key);
+
             if (currentListSize.isPresent() && currentListSize.get() > listSize) {
                 listSize = currentListSize.get();
             }
@@ -214,9 +226,13 @@ public class ConfigurationUtil {
         Set<String> mapKeys = new HashSet<>();
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<List<String>> value = configurationSource.getMapKeys(key);
+
             if (value.isPresent()) {
+
                 for (String s : value.get()) {
+
                     if (!mapKeys.contains(s.replace("-", ""))) {
                         mapKeys.add(s);
                     }
@@ -249,8 +265,11 @@ public class ConfigurationUtil {
     private Optional<String> get(String key, Set<String> processingKeys) {
 
         for (ConfigurationSource configurationSource : config.getConfigurationSources()) {
+
             Optional<String> value = configurationSource.get(key);
+
             if (value.isPresent()) {
+
                 return Optional.of(interpolateString(key, value.get(), processingKeys));
             }
         }
@@ -273,6 +292,7 @@ public class ConfigurationUtil {
 
         int startIndex;
         while((startIndex = s.indexOf("${")) >= 0) {
+
             int endIndex = s.indexOf("}", startIndex + 2);
             String newKey = s.substring(startIndex + 2, endIndex);
 


### PR DESCRIPTION
The updated to the config system in 2.5.0 introduced a regression which prevented the logging system to initialise correctly. A component of the config system created and initialised the default logger before the logging system was initialised causing it to not initialise correctly after the initial config processing phase was completed.

This pull request fixes the regression.