### PR TITLE
Updated the config-mp dependency in the microprofile profiles

### DIFF
--- a/profiles/micro-profile-1.1/pom.xml
+++ b/profiles/micro-profile-1.1/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>kumuluzee-microProfile-1.1</artifactId>
 
     <properties>
-        <version.kumuluzee-config-mp>1.1.0</version.kumuluzee-config-mp>
+        <version.kumuluzee-config-mp>1.1.1</version.kumuluzee-config-mp>
     </properties>
 
     <dependencies>

--- a/profiles/micro-profile-1.2/pom.xml
+++ b/profiles/micro-profile-1.2/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>kumuluzee-microProfile-1.2</artifactId>
 
     <properties>
-        <version.kumuluzee-config-mp>1.1.0</version.kumuluzee-config-mp>
+        <version.kumuluzee-config-mp>1.1.1</version.kumuluzee-config-mp>
         <version.kumuluzee-fault-tolerance>1.0.0</version.kumuluzee-fault-tolerance>
         <version.kumuluzee-health>1.0.0</version.kumuluzee-health>
         <version.kumuluzee-metrics>1.0.0</version.kumuluzee-metrics>


### PR DESCRIPTION
Resolves #88 the issue of the maven build failure caused by misconfigured dependencies in the old config-mp version. 