### PR TITLE
Try raw key if parsed key is not found in environment config source

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/sources/EnvironmentConfigurationSource.java
@@ -45,6 +45,10 @@ public class EnvironmentConfigurationSource implements ConfigurationSource {
             value = System.getenv(parseKeyNameForEnvironmentVariablesLegacy(key));
         }
 
+        if (value == null) {
+            value = System.getenv(key);
+        }
+
         return (value == null) ? Optional.empty() : Optional.of(value);
     }
 


### PR DESCRIPTION
Environment configuration source now tries raw key value, if parsed value is not found.

This is useful when accessing environment variables with lowercase names.