### PR TITLE
Added config property to enable Jetty startup exception propagation

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -35,6 +35,7 @@ public class ServerConfig {
         private Integer maxThreads = 100;
         private Boolean forceHttps = false;
         private Boolean showServerInfo = true;
+        private Boolean forwardStartupException;
 
         private ServerConnectorConfig.Builder http = new ServerConnectorConfig.Builder();
         private ServerConnectorConfig.Builder https;
@@ -84,6 +85,11 @@ public class ServerConfig {
             return this;
         }
 
+        public Builder forwardStartupException(Boolean forwardStartupException) {
+            this.forwardStartupException = forwardStartupException;
+            return this;
+        }
+
         public ServerConfig build() {
 
             ServerConfig serverConfig = new ServerConfig();
@@ -94,6 +100,7 @@ public class ServerConfig {
             serverConfig.maxThreads = maxThreads;
             serverConfig.forceHttps = forceHttps;
             serverConfig.showServerInfo = showServerInfo;
+            serverConfig.forwardStartupException = forwardStartupException;
 
             serverConfig.http = http.build();
             if (https != null) serverConfig.https = https.build();
@@ -109,6 +116,7 @@ public class ServerConfig {
     private Integer maxThreads;
     private Boolean forceHttps;
     private Boolean showServerInfo;
+    private Boolean forwardStartupException;
 
     private ServerConnectorConfig http;
     private ServerConnectorConfig https;
@@ -142,6 +150,10 @@ public class ServerConfig {
 
     public Boolean getShowServerInfo(){
         return showServerInfo;
+    }
+
+    public Boolean getForwardStartupException() {
+        return forwardStartupException;
     }
 
     public ServerConnectorConfig getHttp() {

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -65,6 +65,7 @@ public class EeConfigFactory {
             Optional<Integer> maxThreads = cfg.getInteger("kumuluzee.server.max-threads");
             Optional<Boolean> forceHttps = cfg.getBoolean("kumuluzee.server.force-https");
             Optional<Boolean> showServerInfo = cfg.getBoolean("kumuluzee.server.show-server-info");
+            Optional<Boolean> forwardStartupException = cfg.getBoolean("kumuluzee.server.jetty.forward-startup-exception");
 
             baseUrl.ifPresent(serverBuilder::baseUrl);
             contextPath.ifPresent(serverBuilder::contextPath);
@@ -73,6 +74,7 @@ public class EeConfigFactory {
             maxThreads.ifPresent(serverBuilder::maxThreads);
             forceHttps.ifPresent(serverBuilder::forceHttps);
             showServerInfo.ifPresent(serverBuilder::showServerInfo);
+            forwardStartupException.ifPresent(serverBuilder::forwardStartupException);
         }
 
         ServerConnectorConfig.Builder httpBuilder =
@@ -295,6 +297,7 @@ public class EeConfigFactory {
                 eeConfig.getServer().getMinThreads() == null ||
                 eeConfig.getServer().getMaxThreads() == null ||
                 eeConfig.getServer().getShowServerInfo() == null ||
+                eeConfig.getServer().getForwardStartupException() == null ||
                 eeConfig.getServer().getHttp() == null ||
                 eeConfig.getServer().getHttp().getHttp2() == null ||
                 eeConfig.getServer().getHttp().getProxyForwarding() == null ||

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -133,7 +133,9 @@ public class JettyServletServer implements ServletServer {
 
         appContext.setContextPath(serverConfig.getContextPath());
 
-
+        if (serverConfig.getForwardStartupException() != null) {
+            appContext.setThrowUnavailableOnStartupException(serverConfig.getForwardStartupException());
+        }
 
         if (!Boolean.TRUE.equals(serverConfig.getDirBrowsing())) {
 


### PR DESCRIPTION
Property name: `kumuluzee.server.jetty.forward-startup-exception`

The property allows the propagation of exceptions thrown during Jetty startup phase. If not set or set to `false` the current behaviour is preserved: Jetty logs the exception and marks the `WebAppContext` unavailable. If set to `true`, the exception is propagated further to the KumuluzEE server wrapper.

This property has little use for the end-user but aids in the development of KumuluzEE Arquillian Container Adapter.