### PR TITLE
Fix stopServer method throwing IllegalStateException

### DIFF
--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -91,7 +91,7 @@ public class JettyServletServer implements ServletServer {
         if (server == null)
             throw new IllegalStateException("Jetty has to be initialized before stopping it");
 
-        if (server.isStarted() || server.isStarting())
+        if (server.isStopped() || server.isStopping())
             throw new IllegalStateException("Jetty is not running stopped");
 
         try {

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -92,7 +92,7 @@ public class JettyServletServer implements ServletServer {
             throw new IllegalStateException("Jetty has to be initialized before stopping it");
 
         if (server.isStopped() || server.isStopping())
-            throw new IllegalStateException("Jetty is not running stopped");
+            throw new IllegalStateException("Jetty is already stopped");
 
         try {
             server.stop();


### PR DESCRIPTION
As previously written, the method fails with an IllegalStateException even when the underlying Jetty server has already started.