### PR TITLE
Added support for Java 10 to various components

### DIFF
--- a/components/jax-rs/jersey/pom.xml
+++ b/components/jax-rs/jersey/pom.xml
@@ -107,4 +107,20 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>java9-modules</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                    <version>${activation.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/components/jax-ws/cxf/pom.xml
+++ b/components/jax-ws/cxf/pom.xml
@@ -51,6 +51,27 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>java9-modules</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.xml.ws</groupId>
+                    <artifactId>jaxws-tools</artifactId>
+                    <version>${jaxws-tools.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                    <version>${activation.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/components/jax-ws/cxf/pom.xml
+++ b/components/jax-ws/cxf/pom.xml
@@ -14,10 +14,6 @@
 
     <artifactId>kumuluzee-jax-ws-cxf</artifactId>
 
-    <properties>
-        <cxf.version>3.2.4</cxf.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.kumuluz.ee</groupId>

--- a/components/jax-ws/metro/pom.xml
+++ b/components/jax-ws/metro/pom.xml
@@ -32,4 +32,20 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>java9-modules</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                    <version>${activation.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/components/jpa/hibernate/pom.xml
+++ b/components/jpa/hibernate/pom.xml
@@ -70,4 +70,20 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>java9-modules</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>${jaxb-api.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <jaxb-api.version>2.3.0</jaxb-api.version>
+        <activation.version>1.1.1</activation.version>
+        <jaxws-tools.version>2.3.0.2</jaxws-tools.version>
+
         <annotations.version>1.3.2</annotations.version>
         <inject.version>1</inject.version>
         <interceptor.version>1.2.2</interceptor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,14 @@
         <maven-compile-plugin.version>3.8.0</maven-compile-plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
 
-        <jetty.version>9.4.8.v20171121</jetty.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
         <uel.version>3.0.0</uel.version>
         <weld.version>3.0.5.Final</weld.version>
         <hibernate.validator.version>6.0.11.Final</hibernate.validator.version>
         <jersey.version>2.27</jersey.version>
         <jackson.version>2.8.11</jackson.version>
         <metro.version>2.4.1</metro.version>
+        <cxf.version>3.2.6</cxf.version>
         <hibernate.version>5.3.4.Final</hibernate.version>
         <eclipselink.version>2.7.2</eclipselink.version>
         <mojarra.version>2.4.0</mojarra.version>


### PR DESCRIPTION
Added required dependencies on modules that were removed from JDK in Java 9.

Components affected:

- JAX-RS Jersey
- JAX-WS CXF
- JAX-WS Metro
- JPA Hibernate

Also updated Jetty and JAX-WS CXF versions.