### PR TITLE
Fixed package-info.java loading when running in JAR with Java 9+

### DIFF
--- a/tools/loader/src/main/java/com/kumuluz/ee/loader/EeClassLoader.java
+++ b/tools/loader/src/main/java/com/kumuluz/ee/loader/EeClassLoader.java
@@ -494,6 +494,11 @@ public class EeClassLoader extends ClassLoader {
     }
 
     @Override
+    protected Class<?> findClass(String s) throws ClassNotFoundException {
+        return loadClass(s); // same as loadClass(s, false)
+    }
+
+    @Override
     protected URL findResource(String name) {
 
         debug(String.format("findResource: %s", name));


### PR DESCRIPTION
Defined `findClass` method in JAR class loader. Java 9+ calls this method when loading package-info.java class. The method defined in super-class throws `ClassNotFound` exception and consequently, package level annotations don't work. 