### PR TITLE
Updated Hibernate Validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <jetty.version>9.4.11.v20180605</jetty.version>
         <uel.version>3.0.0</uel.version>
         <weld.version>3.0.5.Final</weld.version>
-        <hibernate.validator.version>6.0.11.Final</hibernate.validator.version>
+        <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>
         <jersey.version>2.27</jersey.version>
         <jackson.version>2.8.11</jackson.version>
         <metro.version>2.4.1</metro.version>


### PR DESCRIPTION
Testing KumuluzEE with a bunch of components (amongst others the Bean Validation-component) I noticed that a SNAPSHOT-version of OpenJFX had become a dependency of KumuluzEE and found that HV was the culprit (https://hibernate.atlassian.net/browse/HV-1644), thus updating HV to 6.0.13.Final which resolves this.