### PR TITLE
Added support for configurable classpath scanning

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/ServletServer.java
+++ b/common/src/main/java/com/kumuluz/ee/common/ServletServer.java
@@ -57,7 +57,7 @@ public interface ServletServer extends KumuluzServer {
 
     void registerTransactionManager(UserTransaction userTransaction);
 
-    void initWebContext();
+    void initWebContext(List<String> scanLibraries);
 
     List<ServletWrapper> getRegisteredServlets();
 }

--- a/common/src/main/java/com/kumuluz/ee/common/attributes/ClasspathAttributes.java
+++ b/common/src/main/java/com/kumuluz/ee/common/attributes/ClasspathAttributes.java
@@ -28,7 +28,7 @@ public class ClasspathAttributes {
 
     public static final String jar = "^((?!lib\\_[^\\/]*\\.jar\\.[^\\/]*\\.tmp|/lib\\_[^\\/]*\\.jar\\.[^\\/]*\\.tmp|.*\\/jre\\/lib\\/.*).)*$";
 
-    public static final String exploded = ".*/classes/.*";
+    public static final String exploded = "^.*/classes/.*$";
 
     public static final String exploded_test = ".*/test-classes/.*";
 }

--- a/common/src/main/java/com/kumuluz/ee/common/config/DevConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/DevConfig.java
@@ -20,6 +20,8 @@
 */
 package com.kumuluz.ee.common.config;
 
+import java.util.List;
+
 /**
  * @author Tilen Faganel
  * @since 2.4.0
@@ -29,6 +31,12 @@ public class DevConfig {
     public static class Builder {
 
         private String webappDir;
+        private List<String> scanLibraries;
+
+        public Builder scanLibraries(List<String> scanLibraries) {
+            this.scanLibraries = scanLibraries;
+            return this;
+        }
 
         public Builder webappDir(String webappDir) {
             this.webappDir = webappDir;
@@ -39,17 +47,23 @@ public class DevConfig {
 
             DevConfig devConfig = new DevConfig();
             devConfig.webappDir = webappDir;
+            devConfig.scanLibraries = scanLibraries;
 
             return devConfig;
         }
     }
 
     private String webappDir;
+    private List<String> scanLibraries;
 
     private DevConfig() {
     }
 
     public String getWebappDir() {
         return webappDir;
+    }
+
+    public List<String> getScanLibraries() {
+        return scanLibraries;
     }
 }

--- a/core/src/main/java/com/kumuluz/ee/EeApplication.java
+++ b/core/src/main/java/com/kumuluz/ee/EeApplication.java
@@ -251,7 +251,14 @@ public class EeApplication {
 
             ServletServer servletServer = (ServletServer) server.getServer();
 
-            servletServer.initWebContext();
+            List<Extension> allExtensions = new ArrayList<>();
+            allExtensions.addAll(eeExtensions.stream().map(ExtensionWrapper::getExtension)
+                    .collect(Collectors.toList()));
+            allExtensions.addAll(eeConfigExtensions.stream().map(ExtensionWrapper::getExtension)
+                    .collect(Collectors.toList()));
+            allExtensions.addAll(eeLogsExtensions.stream().map(ExtensionWrapper::getExtension)
+                    .collect(Collectors.toList()));
+            servletServer.initWebContext(collectScanLibraries(allExtensions));
 
             // Create and register datasources to the underlying server
             if (eeConfig.getDatasources().size() > 0) {
@@ -368,6 +375,14 @@ public class EeApplication {
         server.getServer().startServer();
 
         log.info("KumuluzEE started successfully");
+    }
+
+    private List<String> collectScanLibraries(List<Extension> extensions) {
+        Set<String> scanLibraries = new HashSet<>();
+
+        extensions.stream().filter(Extension::isEnabled).forEach(e -> scanLibraries.addAll(e.scanLibraries()));
+
+        return new ArrayList<>(scanLibraries);
     }
 
     private void processKumuluzServer(KumuluzServer kumuluzServer) {

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -25,6 +25,8 @@ import com.kumuluz.ee.common.utils.EnvUtils;
 import com.kumuluz.ee.common.utils.StringUtils;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -114,6 +116,22 @@ public class EeConfigFactory {
             Optional<String> webappDir = cfg.get("kumuluzee.dev.webapp-dir");
 
             webappDir.ifPresent(devBuilder::webappDir);
+
+            Optional<Integer> scanLibrariesListSize = cfg.getListSize("kumuluzee.dev.scan-libraries");
+
+            if (scanLibrariesListSize.isPresent()) {
+                List<String> scanLibraries = new ArrayList<>();
+
+                for (int i = 0; i < scanLibrariesListSize.get(); i++) {
+                    Optional<String> lib = cfg.get("kumuluzee.dev.scan-libraries[" + i + "]");
+
+                    lib.ifPresent(scanLibraries::add);
+                }
+
+                if (scanLibraries.size() > 0) {
+                    devBuilder.scanLibraries(Collections.unmodifiableList(scanLibraries));
+                }
+            }
 
             eeConfigBuilder.dev(devBuilder);
         }

--- a/servlet/jetty/pom.xml
+++ b/servlet/jetty/pom.xml
@@ -19,6 +19,11 @@
             <groupId>com.kumuluz.ee</groupId>
             <artifactId>kumuluzee-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-loader</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyJarClasspathUtil.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyJarClasspathUtil.java
@@ -17,30 +17,31 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
-package com.kumuluz.ee.common;
+ */
+package com.kumuluz.ee.jetty;
 
-import com.kumuluz.ee.common.config.EeConfig;
-import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
+import com.kumuluz.ee.loader.EeClassLoader;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Tilen Faganel
- * @since 2.3.0
+ * Obtains extra classpath jars from {@link EeClassLoader}. Must be in separate file because {@link EeClassLoader} is
+ * not present on the classpath when running in exploded.
+ *
+ * @author Urban Malc
+ * @since 3.1.0
  */
-public interface Extension {
+public class JettyJarClasspathUtil {
 
-    void load();
+    public static String getExtraClasspath(List<String> scanLibraries) {
 
-    void init(KumuluzServerWrapper server, EeConfig eeConfig);
+        if (!(JettyJarClasspathUtil.class.getClassLoader() instanceof EeClassLoader)) {
+            throw new IllegalStateException("Classloader not instance of EeClassLoader");
+        }
 
-    default boolean isEnabled() {
-        return true;
-    }
+        EeClassLoader eeClassLoader = (EeClassLoader) JettyJarClasspathUtil.class.getClassLoader();
 
-    default List<String> scanLibraries() {
-        return Collections.emptyList();
+        return String.join(",", eeClassLoader
+                .getJarFilesLocations(scanLibraries));
     }
 }

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -22,6 +22,7 @@ package com.kumuluz.ee.jetty;
 
 import com.kumuluz.ee.common.ServletServer;
 import com.kumuluz.ee.common.attributes.ClasspathAttributes;
+import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.common.config.ServerConfig;
 import com.kumuluz.ee.common.dependencies.EeComponentType;
 import com.kumuluz.ee.common.dependencies.ServerDef;
@@ -46,6 +47,7 @@ import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * @author Tilen Faganel
@@ -107,7 +109,7 @@ public class JettyServletServer implements ServletServer {
     }
 
     @Override
-    public void initWebContext() {
+    public void initWebContext(List<String> scanLibraries) {
 
         if (server == null)
             throw new IllegalStateException("Jetty has to be initialized before adding a web context");
@@ -115,18 +117,34 @@ public class JettyServletServer implements ServletServer {
         if (server.isStarted() || server.isStarting())
             throw new IllegalStateException("Jetty cannot be started before adding a web context");
 
+        if (EeConfig.getInstance().getDev().getScanLibraries() != null) {
+            scanLibraries.addAll(EeConfig.getInstance().getDev().getScanLibraries());
+        }
+
         appContext = new WebAppContext();
 
         if (ResourceUtils.isRunningInJar()) {
             appContext.setAttribute(JettyAttributes.jarPattern, ClasspathAttributes.jar);
 
+            appContext.setExtraClasspath(JettyJarClasspathUtil.getExtraClasspath(scanLibraries));
+
             try {
                 appContext.setClassLoader(getClass().getClassLoader());
             } catch (Exception e) {
-                throw new IllegalStateException("Unable to set custom classloader for Jetty");
+                throw new IllegalStateException("Unable to set custom classloader for Jetty", e);
             }
         } else {
-            appContext.setAttribute(JettyAttributes.jarPattern, ClasspathAttributes.exploded);
+            StringBuilder explodedClasspath = new StringBuilder(ClasspathAttributes.exploded);
+            for (String lib : scanLibraries) {
+                if (lib.endsWith(".jar")) {
+                    explodedClasspath.append("|^.*/").append(Pattern.quote(lib)).append("$");
+                } else {
+                    explodedClasspath.append("|^.*/").append(Pattern.quote(lib)).append("-[^/]+\\.jar$");
+                }
+            }
+
+            log.fine("Using classpath scanning regex: " + explodedClasspath.toString());
+            appContext.setAttribute(JettyAttributes.jarPattern, explodedClasspath.toString());
         }
 
         appContext.setParentLoaderPriority(true);


### PR DESCRIPTION
Libraries that need to be scanned can now be specified through common configuration:

```yaml
kumuluzee:
  dev:
    scan-libraries:
      - lib-1.0.0-SNAPSHOT.jar
      - lib2
```

The search is first performed using full library JAR name (<artefact-name>-<version>.jar) and if not found only with artefact name.

Additionally, an extension can specify a list of libraries that need to be scanned in the `scanLibraries()` method:

```java
@EeExtensionDef(name = "SimpleExt", group = "Test")
public class SimpleExtension implements Extension {
    @Override
    public void load() {
    }

    @Override
    public void init(KumuluzServerWrapper kumuluzServerWrapper, EeConfig eeConfig) {
    }

    @Override
    public List<String> scanLibraries() {
        return Collections.singletonList("extTest");
    }
}
```

The same matching rules apply as for common configuration.