### PR TITLE
Updated Jetty to latest version. Resolves invalid ASM warning.

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConnectorConfig.java
@@ -42,7 +42,6 @@ public class ServerConnectorConfig {
         private Integer requestHeaderSize = 8 * 1024;
         private Integer responseHeaderSize = 8 * 1024;
         private Integer idleTimeout = 30 * 1000;
-        private Integer soLingerTime = -1;
 
         private String keystorePath;
         private String keystorePassword;
@@ -91,11 +90,6 @@ public class ServerConnectorConfig {
             return this;
         }
 
-        public Builder soLingerTime(Integer soLingerTime) {
-            this.soLingerTime = soLingerTime;
-            return this;
-        }
-
         public Builder keystorePath(String keystorePath) {
             this.keystorePath = keystorePath;
             return this;
@@ -137,7 +131,6 @@ public class ServerConnectorConfig {
             serverConnectorConfig.requestHeaderSize = requestHeaderSize;
             serverConnectorConfig.responseHeaderSize = responseHeaderSize;
             serverConnectorConfig.idleTimeout = idleTimeout;
-            serverConnectorConfig.soLingerTime = soLingerTime;
             serverConnectorConfig.keystorePath = keystorePath;
             serverConnectorConfig.keystorePassword = keystorePassword;
             serverConnectorConfig.keyAlias = keyAlias;
@@ -157,7 +150,6 @@ public class ServerConnectorConfig {
     private Integer requestHeaderSize;
     private Integer responseHeaderSize;
     private Integer idleTimeout;
-    private Integer soLingerTime;
 
     private String keystorePath;
     private String keystorePassword;
@@ -199,10 +191,6 @@ public class ServerConnectorConfig {
 
     public Integer getIdleTimeout() {
         return idleTimeout;
-    }
-
-    public Integer getSoLingerTime() {
-        return soLingerTime;
     }
 
     public String getKeystorePath() {

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -150,7 +150,6 @@ public class EeConfigFactory {
                 Optional<String> conUrl = cfg.get("kumuluzee.datasources[" + i + "].connection-url");
                 Optional<String> user = cfg.get("kumuluzee.datasources[" + i + "].username");
                 Optional<String> pass = cfg.get("kumuluzee.datasources[" + i + "].password");
-                Optional<Integer> maxPool = cfg.getInteger("kumuluzee.datasources[" + i + "].max-pool-size");
 
                 jndiName.ifPresent(dsc::jndiName);
                 driverClass.ifPresent(dsc::driverClass);
@@ -322,14 +321,12 @@ public class EeConfigFactory {
                 eeConfig.getServer().getHttp().getRequestHeaderSize() == null ||
                 eeConfig.getServer().getHttp().getResponseHeaderSize() == null ||
                 eeConfig.getServer().getHttp().getIdleTimeout() == null ||
-                eeConfig.getServer().getHttp().getSoLingerTime() == null ||
                 (eeConfig.getServer().getHttps() != null &&
                         (eeConfig.getServer().getHttps().getHttp2() == null ||
                                 eeConfig.getServer().getHttps().getProxyForwarding() == null ||
                                 eeConfig.getServer().getHttps().getRequestHeaderSize() == null ||
                                 eeConfig.getServer().getHttps().getResponseHeaderSize() == null ||
-                                eeConfig.getServer().getHttps().getIdleTimeout() == null ||
-                                eeConfig.getServer().getHttps().getSoLingerTime() == null)) ||
+                                eeConfig.getServer().getHttps().getIdleTimeout() == null)) ||
                 eeConfig.getDatasources().stream().anyMatch(ds ->
                         (ds == null || ds.getPool() == null ||
                                 ds.getPool().getAutoCommit() == null ||
@@ -366,7 +363,6 @@ public class EeConfigFactory {
             Optional<Integer> requestHeaderSize = cfg.getInteger(prefix + ".request-header-size");
             Optional<Integer> responseHeaderSize = cfg.getInteger(prefix + ".response-header-size");
             Optional<Integer> idleTimeout = cfg.getInteger(prefix + ".idle-timeout");
-            Optional<Integer> soLingerTime = cfg.getInteger(prefix + ".so-linger-time");
 
             Optional<String> keystorePath = cfg.get(prefix + ".keystore-path");
             Optional<String> keystorePassword = cfg.get(prefix + ".keystore-password");
@@ -383,7 +379,6 @@ public class EeConfigFactory {
             requestHeaderSize.ifPresent(serverConnectorBuilder::requestHeaderSize);
             responseHeaderSize.ifPresent(serverConnectorBuilder::responseHeaderSize);
             idleTimeout.ifPresent(serverConnectorBuilder::idleTimeout);
-            soLingerTime.ifPresent(serverConnectorBuilder::soLingerTime);
 
             keystorePath.ifPresent(serverConnectorBuilder::keystorePath);
             keystorePassword.ifPresent(serverConnectorBuilder::keystorePassword);

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <maven-compile-plugin.version>3.8.0</maven-compile-plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
 
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.14.v20181114</jetty.version>
         <uel.version>3.0.0</uel.version>
         <weld.version>3.0.5.Final</weld.version>
         <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
@@ -135,7 +135,6 @@ public class JettyFactory {
             httpConnector.setHost(httpConfig.getAddress());
 
             httpConnector.setIdleTimeout(httpConfig.getIdleTimeout());
-            httpConnector.setSoLingerTime(httpConfig.getSoLingerTime());
 
             connectors.add(httpConnector);
         }
@@ -215,7 +214,6 @@ public class JettyFactory {
             httpsConnector.setHost(httpsConfig.getAddress());
 
             httpsConnector.setIdleTimeout(httpsConfig.getIdleTimeout());
-            httpsConnector.setSoLingerTime(httpsConfig.getSoLingerTime());
 
             connectors.add(httpsConnector);
         }


### PR DESCRIPTION
Also removed deprecated and unused Jetty parameter so-linger-time.