### PR TITLE
Added Jetty etag header support for static content

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -31,6 +31,7 @@ public class ServerConfig {
         private String baseUrl;
         private String contextPath = "/";
         private Boolean dirBrowsing = false;
+        private Boolean etags = false;
         private Integer minThreads = 5;
         private Integer maxThreads = 100;
         private Boolean forceHttps = false;
@@ -52,6 +53,11 @@ public class ServerConfig {
 
         public Builder dirBrowsing(Boolean dirBrowsing) {
             this.dirBrowsing = dirBrowsing;
+            return this;
+        }
+
+        public Builder etags(Boolean etags) {
+            this.etags = etags;
             return this;
         }
 
@@ -96,6 +102,7 @@ public class ServerConfig {
             serverConfig.baseUrl = baseUrl;
             serverConfig.contextPath = contextPath;
             serverConfig.dirBrowsing = dirBrowsing;
+            serverConfig.etags = etags;
             serverConfig.minThreads = minThreads;
             serverConfig.maxThreads = maxThreads;
             serverConfig.forceHttps = forceHttps;
@@ -112,6 +119,7 @@ public class ServerConfig {
     private String baseUrl;
     private String contextPath;
     private Boolean dirBrowsing;
+    private Boolean etags;
     private Integer minThreads;
     private Integer maxThreads;
     private Boolean forceHttps;
@@ -134,6 +142,10 @@ public class ServerConfig {
 
     public Boolean getDirBrowsing() {
         return dirBrowsing;
+    }
+
+    public Boolean getEtags() {
+        return etags;
     }
 
     public Integer getMinThreads() {

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -63,6 +63,7 @@ public class EeConfigFactory {
             Optional<String> baseUrl = cfg.get("kumuluzee.server.base-url");
             Optional<String> contextPath = cfg.get("kumuluzee.server.context-path");
             Optional<Boolean> dirBrowsing = cfg.getBoolean("kumuluzee.server.dir-browsing");
+            Optional<Boolean> etags = cfg.getBoolean("kumuluzee.server.etags");
             Optional<Integer> minThreads = cfg.getInteger("kumuluzee.server.min-threads");
             Optional<Integer> maxThreads = cfg.getInteger("kumuluzee.server.max-threads");
             Optional<Boolean> forceHttps = cfg.getBoolean("kumuluzee.server.force-https");
@@ -72,6 +73,7 @@ public class EeConfigFactory {
             baseUrl.ifPresent(serverBuilder::baseUrl);
             contextPath.ifPresent(serverBuilder::contextPath);
             dirBrowsing.ifPresent(serverBuilder::dirBrowsing);
+            etags.ifPresent(serverBuilder::etags);
             minThreads.ifPresent(serverBuilder::minThreads);
             maxThreads.ifPresent(serverBuilder::maxThreads);
             forceHttps.ifPresent(serverBuilder::forceHttps);

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyAttributes.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyAttributes.java
@@ -17,7 +17,7 @@
  *  out of or in connection with the software or the use or other dealings in the
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
-*/
+ */
 package com.kumuluz.ee.jetty;
 
 /**
@@ -30,4 +30,6 @@ public class JettyAttributes {
             ".ContainerIncludeJarPattern";
 
     public static final String dirBrowsing = "org.eclipse.jetty.servlet.Default.dirAllowed";
+
+    public static final String etags = "org.eclipse.jetty.servlet.Default.etags";
 }

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -166,6 +166,10 @@ public class JettyServletServer implements ServletServer {
 
             appContext.setInitParameter(JettyAttributes.dirBrowsing, "false");
         }
+
+        if (Boolean.TRUE.equals(serverConfig.getEtags())) {
+            appContext.setInitParameter(JettyAttributes.etags, "true");
+        }
         log.info("Starting KumuluzEE with context root '" + serverConfig.getContextPath() + "'");
 
         // Set the secured redirect handler in case the force https option is selected


### PR DESCRIPTION
Jetty does not generate eTag HTTP header by default for static content served from webapp directory therefore some browsers displays out of date content.

Added new config according to [Jetty docs](https://www.eclipse.org/jetty/javadoc/9.4.12.v20180830/org/eclipse/jetty/servlet/DefaultServlet.html)
kumuluzee:
  server:
    etags: [true, false]