### PR TITLE
downgrade snakeyaml version due to breakage of log4j2 initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <classmate.version>1.5.0</classmate.version>
         <javassist.version>3.24.1-GA</javassist.version>
         <hikari.version>2.7.9</hikari.version>
-        <yaml.version>1.24</yaml.version>
+        <yaml.version>1.18</yaml.version>
         <junit.version>4.12</junit.version>
         <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>


### PR DESCRIPTION
Due to an addition of a `Logger.getlogger` call in snakeyaml library after v1.18 the log4j2 initialization is broken since the call should not be made until the logging manager is set via system property.

Issue is pending upstream: https://bitbucket.org/asomov/snakeyaml/issues/461/trouble-with-loggergetlogger-call-in

In case of no resolution upstream the log4j2 initialization code will have to be cleverly reworked to detect the log4j2 extension without triggering snakeyaml library.

There were no major changes since version 1.18 so the downgrade should have no negative effect.