### PR TITLE
Added missing validator options for connection pool

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/DataSourcePoolConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/DataSourcePoolConfig.java
@@ -60,6 +60,7 @@ public class DataSourcePoolConfig {
         @Deprecated
         private Boolean registerMbeans;
         private String connectionInitSql;
+        private String connectionValidSql;
         private String transactionIsolation;
         private Long validationTimeout = 5000L;
         private Long leakDetectionThreshold = 0L;
@@ -152,6 +153,11 @@ public class DataSourcePoolConfig {
             return this;
         }
 
+        public Builder connectionValidSql(String connectionValidSql) {
+            this.connectionValidSql = connectionValidSql;
+            return this;
+        }
+
         public Builder transactionIsolation(String transactionIsolation) {
             this.transactionIsolation = transactionIsolation;
             return this;
@@ -191,6 +197,7 @@ public class DataSourcePoolConfig {
             dataSourcePoolConfig.readOnly = readOnly;
             dataSourcePoolConfig.registerMbeans = registerMbeans;
             dataSourcePoolConfig.connectionInitSql = connectionInitSql;
+            dataSourcePoolConfig.connectionValidSql = connectionValidSql;
             dataSourcePoolConfig.transactionIsolation = transactionIsolation;
             dataSourcePoolConfig.validationTimeout = validationTimeout;
             dataSourcePoolConfig.leakDetectionThreshold = leakDetectionThreshold;
@@ -232,6 +239,7 @@ public class DataSourcePoolConfig {
     @Deprecated
     private Boolean registerMbeans;
     private String connectionInitSql;
+    private String connectionValidSql;
     private String transactionIsolation;
     private Long validationTimeout;
     private Long leakDetectionThreshold;
@@ -309,6 +317,10 @@ public class DataSourcePoolConfig {
 
     public String getConnectionInitSql() {
         return connectionInitSql;
+    }
+
+    public String getConnectionValidSql() {
+        return connectionValidSql;
     }
 
     public String getTransactionIsolation() {

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -186,6 +186,7 @@ public class EeConfigFactory {
                     Optional<Boolean> readOnly = cfg.getBoolean("kumuluzee.datasources[" + i + "].pool.read-only");
                     Optional<Boolean> registerMbeans = cfg.getBoolean("kumuluzee.datasources[" + i + "].pool.register-mbeans");
                     Optional<String> connectionInitSql = cfg.get("kumuluzee.datasources[" + i + "].pool.connection-init-sql");
+                    Optional<String> connectionValidSql = cfg.get("kumuluzee.datasources[" + i + "].pool.connection-valid-sql");
                     Optional<String> transactionIsolation = cfg.get("kumuluzee.datasources[" + i + "].pool.transaction-isolation");
                     Optional<Long> validationTimeout = cfg.getLong("kumuluzee.datasources[" + i + "].pool.validation-timeout");
                     Optional<Long> leakDetectionThreshold = cfg.getLong("kumuluzee.datasources[" + i + "].pool.leak-detection-threshold");
@@ -207,6 +208,7 @@ public class EeConfigFactory {
                     readOnly.ifPresent(dspc::readOnly);
                     registerMbeans.ifPresent(dspc::registerMbeans);
                     connectionInitSql.ifPresent(dspc::connectionInitSql);
+                    connectionValidSql.ifPresent(dspc::connectionValidSql);
                     transactionIsolation.ifPresent(dspc::transactionIsolation);
                     validationTimeout.ifPresent(dspc::validationTimeout);
                     leakDetectionThreshold.ifPresent(dspc::leakDetectionThreshold);


### PR DESCRIPTION
Current implementation uses Agroal emptyValidator for validating database connections causing all connections to be always valid. Using emptyValidator results in failed sql queries when broken connections are returned from the pool. Connection may be broken due to various reasons e.g. database restart or connection loss.

This change brings use of defaultValidator which periodically checks each connection in the pool to be valid.
User may configure his own sql connection validator using sql provided with configuration key:
`datasources[0].pool.connection-valid-sql`
 