### PR TITLE
Add gzip compression option for jetty

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/GzipConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/GzipConfig.java
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.common.config;
+
+import java.util.List;
+
+public class GzipConfig {
+
+    public static class Builder {
+
+        private Boolean enabled = false;
+        private Integer minGzipSize;
+        private List<String> includedMethods;
+        private List<String> includedMimeTypes;
+        private List<String> excludedMimeTypes;
+        private List<String> excludedAgentPatterns;
+        private List<String> excludedPaths;
+        private List<String> includedPaths;
+
+        public Builder enabled(Boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder minGzipSize(Integer minGzipSize) {
+            this.minGzipSize = minGzipSize;
+            return this;
+        }
+
+        public Builder includedMethods(List<String> includedMethods) {
+            this.includedMethods = includedMethods;
+            return this;
+        }
+
+        public Builder includedMimeTypes(List<String> includedMimeTypes) {
+            this.includedMimeTypes = includedMimeTypes;
+            return this;
+        }
+
+        public Builder excludedMimeTypes(List<String> excludedMimeTypes) {
+            this.excludedMimeTypes = excludedMimeTypes;
+            return this;
+        }
+
+        public Builder excludedAgentPatterns(List<String> excludedAgentPatterns) {
+            this.excludedAgentPatterns = excludedAgentPatterns;
+            return this;
+        }
+
+        public Builder excludedPaths(List<String> excludedPaths) {
+            this.excludedPaths = excludedPaths;
+            return this;
+        }
+
+        public Builder includedPaths(List<String> includedPaths) {
+            this.includedPaths = includedPaths;
+            return this;
+        }
+
+        public GzipConfig build() {
+
+            GzipConfig gzipConfig = new GzipConfig();
+            gzipConfig.enabled = enabled;
+            gzipConfig.minGzipSize = minGzipSize;
+            gzipConfig.includedMethods = includedMethods;
+            gzipConfig.includedMimeTypes = includedMimeTypes;
+            gzipConfig.excludedMimeTypes = excludedMimeTypes;
+            gzipConfig.excludedAgentPatterns = excludedAgentPatterns;
+            gzipConfig.excludedPaths = excludedPaths;
+            gzipConfig.includedPaths = includedPaths;
+
+            return gzipConfig;
+        }
+    }
+
+    private Boolean enabled;
+    private Integer minGzipSize;
+    private List<String> includedMethods;
+    private List<String> includedMimeTypes;
+    private List<String> excludedMimeTypes;
+    private List<String> excludedAgentPatterns;
+    private List<String> excludedPaths;
+    private List<String> includedPaths;
+
+    private GzipConfig() {
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Integer getMinGzipSize() {
+        return minGzipSize;
+    }
+
+    public void setMinGzipSize(Integer minGzipSize) {
+        this.minGzipSize = minGzipSize;
+    }
+
+    public List<String> getIncludedMethods() {
+        return includedMethods;
+    }
+
+    public void setIncludedMethods(List<String> includedMethods) {
+        this.includedMethods = includedMethods;
+    }
+
+    public List<String> getIncludedMimeTypes() {
+        return includedMimeTypes;
+    }
+
+    public void setIncludedMimeTypes(List<String> includedMimeTypes) {
+        this.includedMimeTypes = includedMimeTypes;
+    }
+
+    public List<String> getExcludedMimeTypes() {
+        return excludedMimeTypes;
+    }
+
+    public void setExcludedMimeTypes(List<String> excludedMimeTypes) {
+        this.excludedMimeTypes = excludedMimeTypes;
+    }
+
+    public List<String> getExcludedAgentPatterns() {
+        return excludedAgentPatterns;
+    }
+
+    public void setExcludedAgentPatterns(List<String> excludedAgentPatterns) {
+        this.excludedAgentPatterns = excludedAgentPatterns;
+    }
+
+    public List<String> getExcludedPaths() {
+        return excludedPaths;
+    }
+
+    public void setExcludedPaths(List<String> excludedPaths) {
+        this.excludedPaths = excludedPaths;
+    }
+
+    public List<String> getIncludedPaths() {
+        return includedPaths;
+    }
+
+    public void setIncludedPaths(List<String> includedPaths) {
+        this.includedPaths = includedPaths;
+    }
+}

--- a/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/ServerConfig.java
@@ -41,6 +41,8 @@ public class ServerConfig {
         private ServerConnectorConfig.Builder http = new ServerConnectorConfig.Builder();
         private ServerConnectorConfig.Builder https;
 
+        private GzipConfig.Builder gzip;
+
         public Builder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
             return this;
@@ -86,6 +88,11 @@ public class ServerConfig {
             return this;
         }
 
+        public Builder gzip(GzipConfig.Builder gzip) {
+            this.gzip = gzip;
+            return this;
+        }
+
         public Builder showServerInfo(Boolean showServerInfo) {
             this.showServerInfo = showServerInfo;
             return this;
@@ -112,6 +119,8 @@ public class ServerConfig {
             serverConfig.http = http.build();
             if (https != null) serverConfig.https = https.build();
 
+            if (gzip != null) serverConfig.gzip = gzip.build();
+
             return serverConfig;
         }
     }
@@ -128,6 +137,8 @@ public class ServerConfig {
 
     private ServerConnectorConfig http;
     private ServerConnectorConfig https;
+
+    private GzipConfig gzip;
 
     private ServerConfig() {
     }
@@ -174,5 +185,9 @@ public class ServerConfig {
 
     public ServerConnectorConfig getHttps() {
         return https;
+    }
+
+    public GzipConfig getGzip() {
+        return gzip;
     }
 }

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -23,7 +23,9 @@ package com.kumuluz.ee.jetty;
 import com.kumuluz.ee.common.ServletServer;
 import com.kumuluz.ee.common.attributes.ClasspathAttributes;
 import com.kumuluz.ee.common.config.EeConfig;
+import com.kumuluz.ee.common.config.GzipConfig;
 import com.kumuluz.ee.common.config.ServerConfig;
+import com.kumuluz.ee.common.config.ServerConnectorConfig;
 import com.kumuluz.ee.common.dependencies.EeComponentType;
 import com.kumuluz.ee.common.dependencies.ServerDef;
 import com.kumuluz.ee.common.exceptions.KumuluzServerException;
@@ -35,6 +37,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.SecuredRedirectHandler;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -172,14 +175,46 @@ public class JettyServletServer implements ServletServer {
         }
         log.info("Starting KumuluzEE with context root '" + serverConfig.getContextPath() + "'");
 
-        // Set the secured redirect handler in case the force https option is selected
-        if (serverConfig.getForceHttps()) {
+        GzipConfig gzipConfig = serverConfig.getGzip();
 
-            HandlerList handlers = new HandlerList();
-            handlers.setHandlers(new Handler[]
-                    {new SecuredRedirectHandler(), appContext});
+        if (serverConfig.getForceHttps() || (gzipConfig != null && gzipConfig.getEnabled())) {
 
-            server.setHandler(handlers);
+            final ArrayList<Handler> handlers = new ArrayList<>();
+
+            // Set the secured redirect handler in case the force https option is selected
+            if( serverConfig.getForceHttps()) {
+                handlers.add(new SecuredRedirectHandler());
+            }
+
+            // Set the gzip handler in case the use gzip option is selected
+            if(gzipConfig != null && gzipConfig.getEnabled()) {
+                GzipHandler gzipHandler = new GzipHandler();
+
+                if(gzipConfig.getMinGzipSize() != null)
+                    gzipHandler.setMinGzipSize(gzipConfig.getMinGzipSize());
+                if(gzipConfig.getIncludedMethods() != null)
+                    gzipHandler.setIncludedMethods(gzipConfig.getIncludedMethods().toArray(new String[0]));
+                if(gzipConfig.getIncludedMimeTypes() != null)
+                    gzipHandler.setIncludedMimeTypes(gzipConfig.getIncludedMimeTypes().toArray(new String[0]));
+                if(gzipConfig.getExcludedMimeTypes() != null)
+                    gzipHandler.setExcludedMimeTypes(gzipConfig.getExcludedMimeTypes().toArray(new String[0]));
+                if(gzipConfig.getExcludedAgentPatterns() != null)
+                    gzipHandler.setExcludedAgentPatterns(gzipConfig.getExcludedAgentPatterns().toArray(new String[0]));
+                if(gzipConfig.getExcludedPaths() != null)
+                    gzipHandler.setExcludedPaths(gzipConfig.getExcludedPaths().toArray(new String[0]));
+                if(gzipConfig.getIncludedPaths() != null)
+                    gzipHandler.setIncludedPaths(gzipConfig.getIncludedPaths().toArray(new String[0]));
+
+                gzipHandler.setHandler(appContext);
+                handlers.add(gzipHandler);
+            } else {
+                handlers.add(appContext);
+            }
+
+            HandlerList handlerList = new HandlerList();
+            handlerList.setHandlers(handlers.toArray(new Handler[0]));
+
+            server.setHandler(handlerList);
         } else {
 
             server.setHandler(appContext);


### PR DESCRIPTION
Hello :)

I added an option (`kumuluzee.server.http.use-gzip`) to be able to active gzip compression on demand for Jetty via `GzipHandler` mechanism.

It makes a huge difference when working on big payload Rest API.

Tell me if you want to be able to configure more deeply the `GzipHandler` or anything else.

Have a nice day!

Flavien