### PR TITLE
Loading of ConfigurationSources via ServiceLoader

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/configuration/ConfigurationSource.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/ConfigurationSource.java
@@ -66,4 +66,6 @@ public interface ConfigurationSource {
     default Integer getOrdinal() {
         return getInteger(CONFIG_ORDINAL).orElse(100);
     }
+
+    default void postInit() {}
 }

--- a/common/src/main/resources/META-INF/services/com.kumuluz.ee.configuration.ConfigurationSource
+++ b/common/src/main/resources/META-INF/services/com.kumuluz.ee.configuration.ConfigurationSource
@@ -1,0 +1,4 @@
+com.kumuluz.ee.configuration.sources.EnvironmentConfigurationSource
+com.kumuluz.ee.configuration.sources.FileConfigurationSource
+com.kumuluz.ee.configuration.sources.SystemPropertyConfigurationSource
+


### PR DESCRIPTION
This provides the ability to define custom server configuration sources before the server is initialized. This allows us to autoprovision for example databases based on external configuration services.