### PR TITLE
Allow framework start up with bad db connection

### DIFF
--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/injection/JpaService.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/injection/JpaService.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 @Priority(1)
 public class JpaService implements JpaInjectionServices {
 
-    private Logger log = Logger.getLogger(JpaService.class.getSimpleName());;
+    private static final Logger log = Logger.getLogger(JpaService.class.getSimpleName());
 
     @Override
     public ResourceReferenceFactory<EntityManager> registerPersistenceContextInjectionPoint

--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/injection/JpaService.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/injection/JpaService.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 @Priority(1)
 public class JpaService implements JpaInjectionServices {
 
-    private static final Logger log = Logger.getLogger(JpaService.class.getSimpleName());
+    private static final Logger LOG = Logger.getLogger(JpaService.class.getSimpleName());
 
     @Override
     public ResourceReferenceFactory<EntityManager> registerPersistenceContextInjectionPoint
@@ -91,12 +91,12 @@ public class JpaService implements JpaInjectionServices {
         }
         catch (Exception e) {
             if (!continueOnError) {
-                log.severe("EntityManager for pu "+unitName+" failed to initialize. KumuluzEE initialization failed.");
+                LOG.severe("EntityManager for pu "+unitName+" failed to initialize. KumuluzEE initialization failed.");
                 throw e;
             }
         }
 
-        log.warning("EntityManager for pu "+unitName+" failed to initialize. KumuluzEE will continue the startup regardless due to config override.");
+        LOG.warning("EntityManager for pu "+unitName+" failed to initialize. KumuluzEE will continue the startup regardless due to config override.");
         return null;
     }
 


### PR DESCRIPTION
New configuration section for persistence units with an option to continue the startup on db connection error on init. Default remains fail-fast.