### PR TITLE
Fix Agroal-Narayana integration

### DIFF
--- a/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/JtaProvider.java
+++ b/components/jta/common/src/main/java/com/kumuluz/ee/jta/common/JtaProvider.java
@@ -64,5 +64,5 @@ public abstract class JtaProvider {
 
     public abstract TransactionSynchronizationRegistry getTransactionSynchronizationRegistry();
 
-    public abstract TransactionIntegration getTransactionIntegration();
+    public abstract TransactionIntegration getTransactionIntegration(String jndiName);
 }

--- a/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaJtaProvider.java
+++ b/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaJtaProvider.java
@@ -26,9 +26,7 @@ import com.kumuluz.ee.jta.common.JtaProvider;
 import io.agroal.api.transaction.TransactionIntegration;
 import io.agroal.narayana.NarayanaTransactionIntegration;
 
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
+import javax.transaction.*;
 
 /**
  * @author Marcos Koch Salvador
@@ -36,12 +34,10 @@ import javax.transaction.UserTransaction;
  */
 public class NarayanaJtaProvider extends JtaProvider {
 
-    private JTAEnvironmentBean jtaEnvironment;
-    private TransactionIntegration txIntegration;
+    private final JTAEnvironmentBean jtaEnvironment;
 
     public NarayanaJtaProvider() {
         jtaEnvironment = jtaPropertyManager.getJTAEnvironmentBean();
-        txIntegration = new NarayanaTransactionIntegration(jtaEnvironment.getTransactionManager(), jtaEnvironment.getTransactionSynchronizationRegistry());
     }
 
     @Override
@@ -60,8 +56,9 @@ public class NarayanaJtaProvider extends JtaProvider {
     }
 
     @Override
-    public TransactionIntegration getTransactionIntegration() {
-        return txIntegration;
+    public TransactionIntegration getTransactionIntegration(String jndiName) {
+        return new NarayanaTransactionIntegration(getTransactionManager(), getTransactionSynchronizationRegistry(),
+                jndiName);
     }
 
 }

--- a/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaJtaProvider.java
+++ b/components/jta/narayana/src/main/java/com/kumuluz/ee/jta/narayana/NarayanaJtaProvider.java
@@ -27,6 +27,8 @@ import io.agroal.api.transaction.TransactionIntegration;
 import io.agroal.narayana.NarayanaTransactionIntegration;
 
 import javax.transaction.*;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Marcos Koch Salvador
@@ -35,9 +37,11 @@ import javax.transaction.*;
 public class NarayanaJtaProvider extends JtaProvider {
 
     private final JTAEnvironmentBean jtaEnvironment;
+    private final Map<String, NarayanaTransactionIntegration> transactionIntegrations;
 
     public NarayanaJtaProvider() {
         jtaEnvironment = jtaPropertyManager.getJTAEnvironmentBean();
+        transactionIntegrations = new HashMap<>();
     }
 
     @Override
@@ -57,8 +61,13 @@ public class NarayanaJtaProvider extends JtaProvider {
 
     @Override
     public TransactionIntegration getTransactionIntegration(String jndiName) {
-        return new NarayanaTransactionIntegration(getTransactionManager(), getTransactionSynchronizationRegistry(),
-                jndiName);
+
+        if (!transactionIntegrations.containsKey(jndiName)) {
+            transactionIntegrations.put(jndiName, new NarayanaTransactionIntegration(getTransactionManager(),
+                    getTransactionSynchronizationRegistry(), jndiName));
+        }
+
+        return transactionIntegrations.get(jndiName);
     }
 
 }

--- a/core/src/main/java/com/kumuluz/ee/factories/AgroalDataSourceFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/AgroalDataSourceFactory.java
@@ -42,7 +42,7 @@ public class AgroalDataSourceFactory {
         if (!jtaPresent) {
             dataSourceConfig.dataSourceImplementation(DataSourceImplementation.HIKARI);
         } else {
-            poolConfig.transactionIntegration( JtaProvider.getInstance().getTransactionIntegration() );
+            poolConfig.transactionIntegration( JtaProvider.getInstance().getTransactionIntegration(dsc.getJndiName()) );
         }
 
         if (!StringUtils.isNullOrEmpty( dsc.getDriverClass() )) {
@@ -76,7 +76,7 @@ public class AgroalDataSourceFactory {
         AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfig = poolConfig.connectionFactoryConfiguration();
 
         if (jtaPresent) {
-            poolConfig.transactionIntegration( JtaProvider.getInstance().getTransactionIntegration() );
+            poolConfig.transactionIntegration( JtaProvider.getInstance().getTransactionIntegration(xdsc.getJndiName()) );
         }
 
         if (!StringUtils.isNullOrEmpty( xdsc.getXaDatasourceClass() )) {

--- a/core/src/main/java/com/kumuluz/ee/factories/AgroalDataSourceFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/AgroalDataSourceFactory.java
@@ -20,9 +20,11 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * @author Marcos Koch Salvador
@@ -196,14 +198,25 @@ public class AgroalDataSourceFactory {
     private static void setJdbcTransactionIsolation(AgroalConnectionFactoryConfigurationSupplier connectionFactory, String transactionIsolation) {
         if (!StringUtils.isNullOrEmpty( transactionIsolation )) {
 
+            boolean found = false;
+
             for (TransactionIsolation isolation : TransactionIsolation.values()) {
 
                 final String isolationName = "TRANSACTION_" + isolation.name();
 
-                if (isolationName.equals(isolation)) {
+                if (isolationName.equalsIgnoreCase(transactionIsolation)) {
                     connectionFactory.jdbcTransactionIsolation(isolation);
+                    found = true;
                     break;
                 }
+            }
+
+            if (!found) {
+                log.warning("Could not find transaction isolation level with name: " + transactionIsolation +
+                        ", possible values: " + Arrays.stream(TransactionIsolation.values())
+                        .map(Enum::name)
+                        .map(n -> "TRANSACTION_" + n)
+                        .collect(Collectors.joining(", ")));
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <classmate.version>1.5.0</classmate.version>
         <javassist.version>3.24.1-GA</javassist.version>
-        <agroal.version>1.7</agroal.version>
+        <agroal.version>1.8</agroal.version>
         <yaml.version>1.26</yaml.version>
         <junit.version>4.12</junit.version>
         <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
@@ -87,7 +87,7 @@
         <mojarra.version>2.4.0</mojarra.version>
         <jsonp-impl.version>1.1.4</jsonp-impl.version>
         <yasson.version>1.0.3</yasson.version>
-        <narayana.version>5.9.4.Final</narayana.version>
+        <narayana.version>5.10.6.Final</narayana.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <javamail-ri.version>1.6.2</javamail-ri.version>
     </properties>


### PR DESCRIPTION
Fixed bug: When performing queries to multiple databases in a single XA transaction all queries were performed on the first database that was defined.

Also fixed incorrect parsing of `transaction-isolation` config parameter and upped minor versions of Agroal and Narayana.