### PR TITLE
lift jersey dependency to 2.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <uel.version>3.0.0</uel.version>
         <weld.version>3.1.1.Final</weld.version>
         <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
-        <jersey.version>2.28</jersey.version>
+        <jersey.version>2.32</jersey.version>
         <jackson.version>2.10.4</jackson.version>
         <metro.version>2.4.1</metro.version>
         <cxf.version>3.2.6</cxf.version>


### PR DESCRIPTION
Tested with a couple of services, no real issues found.