### PR TITLE
Fixed crash when using CDI without JAX-RS

### DIFF
--- a/components/cdi/weld/pom.xml
+++ b/components/cdi/weld/pom.xml
@@ -63,17 +63,6 @@
 
         <dependency>
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
-            <artifactId>jersey-cdi1x</artifactId>
-            <version>${jersey.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-cdi1x-ban-custom-hk2-binding</artifactId>
             <version>${jersey.version}</version>
             <exclusions>

--- a/components/jax-rs/jersey/pom.xml
+++ b/components/jax-rs/jersey/pom.xml
@@ -63,6 +63,21 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.ext.cdi</groupId>
+            <artifactId>jersey-cdi1x</artifactId>
+            <version>${jersey.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>


### PR DESCRIPTION
Last Jersey upgrade caused application crash when running KumuluzEE with CDI and without JAX-RS. This PR fixes it.