### PR TITLE
Migrated to Jetty 10/JakartaEE 8

### DIFF
--- a/.github/workflows/kumuluzee-ci.yml
+++ b/.github/workflows/kumuluzee-ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: ['1.8', '11', '15']
+        java-version: ['11', '15']
 
     steps:
       - name: Checkout code

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,16 +18,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
 
         <dependency>

--- a/common/src/main/java/com/kumuluz/ee/common/config/GzipConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/GzipConfig.java
@@ -143,14 +143,6 @@ public class GzipConfig {
         this.excludedMimeTypes = excludedMimeTypes;
     }
 
-    public List<String> getExcludedAgentPatterns() {
-        return excludedAgentPatterns;
-    }
-
-    public void setExcludedAgentPatterns(List<String> excludedAgentPatterns) {
-        this.excludedAgentPatterns = excludedAgentPatterns;
-    }
-
     public List<String> getExcludedPaths() {
         return excludedPaths;
     }

--- a/components/bean-validation/hibernate-validator/pom.xml
+++ b/components/bean-validation/hibernate-validator/pom.xml
@@ -73,8 +73,8 @@
                     <artifactId>jersey-server</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.hibernate</groupId>

--- a/components/bean-validation/hibernate-validator/pom.xml
+++ b/components/bean-validation/hibernate-validator/pom.xml
@@ -36,7 +36,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-cdi</artifactId>
             <version>${hibernate.validator.version}</version>
             <exclusions>

--- a/components/cdi/weld/pom.xml
+++ b/components/cdi/weld/pom.xml
@@ -21,12 +21,18 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.ejb</groupId>
+                    <artifactId>jakarta.ejb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
         </dependency>
 
         <dependency>

--- a/components/cdi/weld/pom.xml
+++ b/components/cdi/weld/pom.xml
@@ -42,7 +42,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.spec.javax.annotation</groupId>
-                    <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.jboss.spec.javax.el</groupId>

--- a/components/el/uel/pom.xml
+++ b/components/el/uel/pom.xml
@@ -22,7 +22,7 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <version>${uel.version}</version>
         </dependency>
     </dependencies>

--- a/components/jax-rs/jersey/pom.xml
+++ b/components/jax-rs/jersey/pom.xml
@@ -82,6 +82,36 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-jetty-connector</artifactId>
+            <version>${jersey.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${jetty.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>${activation.version}</version>

--- a/components/jax-rs/jersey/pom.xml
+++ b/components/jax-rs/jersey/pom.xml
@@ -64,18 +64,12 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
-            <artifactId>jersey-cdi1x</artifactId>
+            <artifactId>jersey-cdi1x-servlet</artifactId>
             <version>${jersey.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>
@@ -86,27 +80,17 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
-    </dependencies>
 
-    <profiles>
-        <profile>
-            <id>java9-modules</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>activation</artifactId>
-                    <version>${activation.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <version>${jaxb-api.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>${activation.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/components/jax-rs/jersey/src/main/java/com/kumuluz/ee/jaxrs/Jetty10ConnectorProvider.java
+++ b/components/jax-rs/jersey/src/main/java/com/kumuluz/ee/jaxrs/Jetty10ConnectorProvider.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.jaxrs;
+
+import org.glassfish.jersey.client.spi.Connector;
+import org.glassfish.jersey.client.spi.ConnectorProvider;
+import org.glassfish.jersey.jetty.connector.Jetty10Connector;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Configuration;
+
+/**
+ * Jersey connection provider for Jetty 10.
+ *
+ * @author Urban Malc
+ * @since 4.0.0
+ */
+public class Jetty10ConnectorProvider implements ConnectorProvider {
+
+    @Override
+    public Connector getConnector(Client client, Configuration runtimeConfig) {
+        return new Jetty10Connector(client, runtimeConfig);
+    }
+}

--- a/components/jax-rs/jersey/src/main/java/org/glassfish/jersey/jetty/connector/Jetty10Connector.java
+++ b/components/jax-rs/jersey/src/main/java/org/glassfish/jersey/jetty/connector/Jetty10Connector.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.jetty.connector;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.CookieStore;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.MultivaluedMap;
+
+import javax.net.ssl.SSLContext;
+
+import org.eclipse.jetty.client.dynamic.HttpClientTransportDynamic;
+import org.eclipse.jetty.client.util.BasicAuthentication;
+import org.eclipse.jetty.client.util.BytesContentProvider;
+import org.eclipse.jetty.client.util.FutureResponseListener;
+import org.eclipse.jetty.client.util.OutputStreamContentProvider;
+import org.eclipse.jetty.io.ClientConnector;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.ClientResponse;
+import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
+import org.glassfish.jersey.client.spi.Connector;
+import org.glassfish.jersey.internal.util.collection.ByteBufferInputStream;
+import org.glassfish.jersey.internal.util.collection.NonBlockingInputStream;
+import org.glassfish.jersey.message.internal.HeaderUtils;
+import org.glassfish.jersey.message.internal.OutboundMessageContext;
+import org.glassfish.jersey.message.internal.Statuses;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.ProxyConfiguration;
+import org.eclipse.jetty.client.api.AuthenticationStore;
+import org.eclipse.jetty.client.api.ContentProvider;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.util.HttpCookieStore;
+import org.eclipse.jetty.util.Jetty;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+/**
+ * A {@link Connector} that utilizes the Jetty HTTP Client to send and receive
+ * HTTP request and responses.
+ * <p/>
+ * The following properties are only supported at construction of this class:
+ * <ul>
+ * <li>{@link ClientProperties#ASYNC_THREADPOOL_SIZE}</li>
+ * <li>{@link ClientProperties#CONNECT_TIMEOUT}</li>
+ * <li>{@link ClientProperties#FOLLOW_REDIRECTS}</li>
+ * <li>{@link ClientProperties#PROXY_URI}</li>
+ * <li>{@link ClientProperties#PROXY_USERNAME}</li>
+ * <li>{@link ClientProperties#PROXY_PASSWORD}</li>
+ * <li>{@link ClientProperties#PROXY_PASSWORD}</li>
+ * <li>{@link JettyClientProperties#PREEMPTIVE_BASIC_AUTHENTICATION}</li>
+ * <li>{@link JettyClientProperties#DISABLE_COOKIES}</li>
+ * </ul>
+ * <p/>
+ * This transport supports both synchronous and asynchronous processing of client requests.
+ * The following methods are supported: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, CONNECT and MOVE.
+ * <p/>
+ * Typical usage:
+ * <p/>
+ * <pre>
+ * {@code
+ * ClientConfig config = new ClientConfig();
+ * Connector connector = new JettyConnector(config);
+ * config.connector(connector);
+ * Client client = ClientBuilder.newClient(config);
+ *
+ * // async request
+ * WebTarget target = client.target("http://localhost:8080");
+ * Future<Response> future = target.path("resource").request().async().get();
+ *
+ * // wait for 3 seconds
+ * Response response = future.get(3, TimeUnit.SECONDS);
+ * String entity = response.readEntity(String.class);
+ * client.close();
+ * }
+ * </pre>
+ * <p>
+ * This connector supports only {@link org.glassfish.jersey.client.RequestEntityProcessing#BUFFERED entity buffering}.
+ * Defining the property {@link ClientProperties#REQUEST_ENTITY_PROCESSING} has no effect on this connector.
+ * </p>
+ *
+ * Adapted from org.glassfish.jersey.jetty.connector.JettyConnector for Jetty 10:
+ *  - updated SSL context initialization
+ *  - updated header handling
+ *
+ * @author Arul Dhesiaseelan (aruld at acm.org)
+ * @author Marek Potociar
+ */
+public class Jetty10Connector implements Connector {
+
+    private static final Logger LOGGER = Logger.getLogger(Jetty10Connector.class.getName());
+
+    private final HttpClient client;
+    private final CookieStore cookieStore;
+    private final Configuration configuration;
+    private final Optional<Integer> syncListenerResponseMaxSize;
+
+    /**
+     * Create the new Jetty client connector.
+     *
+     * @param jaxrsClient JAX-RS client instance, for which the connector is created.
+     * @param config client configuration.
+     */
+    public Jetty10Connector(final Client jaxrsClient, final Configuration config) {
+        this.configuration = config;
+        HttpClient httpClient = null;
+        if (config.isRegistered(JettyHttpClientSupplier.class)) {
+            Optional<Object> contract = config.getInstances().stream()
+                    .filter(a-> JettyHttpClientSupplier.class.isInstance(a)).findFirst();
+            if (contract.isPresent()) {
+                httpClient = ((JettyHttpClientSupplier) contract.get()).getHttpClient();
+            }
+        }
+        if (httpClient == null) {
+            final SSLContext sslContext = jaxrsClient.getSslContext();
+            final SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+            sslContextFactory.setSslContext(sslContext);
+
+            ClientConnector clientConnector = new ClientConnector();
+            clientConnector.setSslContextFactory(sslContextFactory);
+
+            httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector));
+        }
+        this.client = httpClient;
+
+        Boolean enableHostnameVerification = (Boolean) config.getProperties()
+                .get(JettyClientProperties.ENABLE_SSL_HOSTNAME_VERIFICATION);
+        if (enableHostnameVerification != null && enableHostnameVerification) {
+            client.getSslContextFactory().setEndpointIdentificationAlgorithm("https");
+        }
+
+        final Object connectTimeout = config.getProperties().get(ClientProperties.CONNECT_TIMEOUT);
+        if (connectTimeout != null && connectTimeout instanceof Integer && (Integer) connectTimeout > 0) {
+            client.setConnectTimeout((Integer) connectTimeout);
+        }
+        final Object threadPoolSize = config.getProperties().get(ClientProperties.ASYNC_THREADPOOL_SIZE);
+        if (threadPoolSize != null && threadPoolSize instanceof Integer && (Integer) threadPoolSize > 0) {
+            final String name = HttpClient.class.getSimpleName() + "@" + hashCode();
+            final QueuedThreadPool threadPool = new QueuedThreadPool((Integer) threadPoolSize);
+            threadPool.setName(name);
+            client.setExecutor(threadPool);
+        }
+        Boolean disableCookies = (Boolean) config.getProperties().get(JettyClientProperties.DISABLE_COOKIES);
+        disableCookies = (disableCookies != null) ? disableCookies : false;
+
+        final AuthenticationStore auth = client.getAuthenticationStore();
+        final Object basicAuthProvider = config.getProperty(JettyClientProperties.PREEMPTIVE_BASIC_AUTHENTICATION);
+        if (basicAuthProvider != null && (basicAuthProvider instanceof BasicAuthentication)) {
+            auth.addAuthentication((BasicAuthentication) basicAuthProvider);
+        }
+
+        final Object proxyUri = config.getProperties().get(ClientProperties.PROXY_URI);
+        if (proxyUri != null) {
+            final URI u = getProxyUri(proxyUri);
+            final ProxyConfiguration proxyConfig = client.getProxyConfiguration();
+            proxyConfig.getProxies().add(new HttpProxy(u.getHost(), u.getPort()));
+
+            final Object proxyUsername = config.getProperties().get(ClientProperties.PROXY_USERNAME);
+            if (proxyUsername != null) {
+                final Object proxyPassword = config.getProperties().get(ClientProperties.PROXY_PASSWORD);
+                auth.addAuthentication(new BasicAuthentication(u, "<<ANY_REALM>>",
+                        String.valueOf(proxyUsername), String.valueOf(proxyPassword)));
+            }
+        }
+
+        if (disableCookies) {
+            client.setCookieStore(new HttpCookieStore.Empty());
+        }
+
+        final Object slResponseMaxSize = configuration.getProperties()
+                .get(JettyClientProperties.SYNC_LISTENER_RESPONSE_MAX_SIZE);
+        if (slResponseMaxSize != null && slResponseMaxSize instanceof Integer
+                && (Integer) slResponseMaxSize > 0) {
+            this.syncListenerResponseMaxSize = Optional.of((Integer) slResponseMaxSize);
+        }
+        else {
+            this.syncListenerResponseMaxSize = Optional.empty();
+        }
+
+        try {
+            client.start();
+        } catch (final Exception e) {
+            throw new ProcessingException("Failed to start the client.", e);
+        }
+        this.cookieStore = client.getCookieStore();
+    }
+
+    @SuppressWarnings("ChainOfInstanceofChecks")
+    private static URI getProxyUri(final Object proxy) {
+        if (proxy instanceof URI) {
+            return (URI) proxy;
+        } else if (proxy instanceof String) {
+            return URI.create((String) proxy);
+        } else {
+            throw new ProcessingException(LocalizationMessages.WRONG_PROXY_URI_TYPE(ClientProperties.PROXY_URI));
+        }
+    }
+
+    /**
+     * Get the {@link HttpClient}.
+     *
+     * @return the {@link HttpClient}.
+     */
+    @SuppressWarnings("UnusedDeclaration")
+    public HttpClient getHttpClient() {
+        return client;
+    }
+
+    /**
+     * Get the {@link CookieStore}.
+     *
+     * @return the {@link CookieStore} instance or null when
+     * JettyClientProperties.DISABLE_COOKIES set to true.
+     */
+    public CookieStore getCookieStore() {
+        return cookieStore;
+    }
+
+    @Override
+    public ClientResponse apply(final ClientRequest jerseyRequest) throws ProcessingException {
+        final Request jettyRequest = translateRequest(jerseyRequest);
+        final Map<String, String> clientHeadersSnapshot = writeOutBoundHeaders(jerseyRequest.getHeaders(), jettyRequest);
+        final ContentProvider entity = getBytesProvider(jerseyRequest);
+        if (entity != null) {
+            jettyRequest.content(entity);
+        }
+
+        try {
+            final ContentResponse jettyResponse;
+            if (!syncListenerResponseMaxSize.isPresent()) {
+                jettyResponse = jettyRequest.send();
+            }
+            else {
+                final FutureResponseListener listener
+                        = new FutureResponseListener(jettyRequest, syncListenerResponseMaxSize.get());
+                jettyRequest.send(listener);
+                jettyResponse = listener.get();
+            }
+            HeaderUtils.checkHeaderChanges(clientHeadersSnapshot, jerseyRequest.getHeaders(),
+                    Jetty10Connector.this.getClass().getName(), jerseyRequest.getConfiguration());
+
+            final javax.ws.rs.core.Response.StatusType status = jettyResponse.getReason() == null
+                    ? Statuses.from(jettyResponse.getStatus())
+                    : Statuses.from(jettyResponse.getStatus(), jettyResponse.getReason());
+
+            final ClientResponse jerseyResponse = new ClientResponse(status, jerseyRequest);
+            processResponseHeaders(jettyResponse.getHeaders(), jerseyResponse);
+            try {
+                jerseyResponse.setEntityStream(new Jetty10Connector.HttpClientResponseInputStream(jettyResponse));
+            } catch (final IOException e) {
+                LOGGER.log(Level.SEVERE, null, e);
+            }
+
+            return jerseyResponse;
+        } catch (final Exception e) {
+            throw new ProcessingException(e);
+        }
+    }
+
+    private static void processResponseHeaders(final HttpFields respHeaders, final ClientResponse jerseyResponse) {
+        for (final HttpField header : respHeaders) {
+            final String headerName = header.getName();
+            final MultivaluedMap<String, String> headers = jerseyResponse.getHeaders();
+            List<String> list = headers.get(headerName);
+            if (list == null) {
+                list = new ArrayList<>();
+            }
+            list.add(header.getValue());
+            headers.put(headerName, list);
+        }
+    }
+
+    private static final class HttpClientResponseInputStream extends FilterInputStream {
+
+        HttpClientResponseInputStream(final ContentResponse jettyResponse) throws IOException {
+            super(getInputStream(jettyResponse));
+        }
+
+        private static InputStream getInputStream(final ContentResponse response) {
+            return new ByteArrayInputStream(response.getContent());
+        }
+    }
+
+    private Request translateRequest(final ClientRequest clientRequest) {
+
+        final URI uri = clientRequest.getUri();
+        final Request request = client.newRequest(uri);
+        request.method(clientRequest.getMethod());
+
+        request.followRedirects(clientRequest.resolveProperty(ClientProperties.FOLLOW_REDIRECTS, true));
+        final Object readTimeout = clientRequest.resolveProperty(ClientProperties.READ_TIMEOUT, -1);
+        if (readTimeout != null && readTimeout instanceof Integer && (Integer) readTimeout > 0) {
+            request.timeout((Integer) readTimeout, TimeUnit.MILLISECONDS);
+        }
+        return request;
+    }
+
+    private Map<String, String> writeOutBoundHeaders(final MultivaluedMap<String, Object> headers, final Request request) {
+        final Map<String, String> stringHeaders = HeaderUtils.asStringHeadersSingleValue(headers, configuration);
+
+        // remove User-agent header set by Jetty; Jersey already sets this in its request (incl. Jetty version)
+
+        request.headers(httpFields -> {
+            httpFields.remove(HttpHeader.USER_AGENT);
+            for (final Map.Entry<String, String> e : stringHeaders.entrySet()) {
+                httpFields.add(e.getKey(), e.getValue());
+            }
+        });
+
+        return stringHeaders;
+    }
+
+    private ContentProvider getBytesProvider(final ClientRequest clientRequest) {
+        final Object entity = clientRequest.getEntity();
+
+        if (entity == null) {
+            return null;
+        }
+
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        clientRequest.setStreamProvider(new OutboundMessageContext.StreamProvider() {
+            @Override
+            public OutputStream getOutputStream(final int contentLength) throws IOException {
+                return outputStream;
+            }
+        });
+
+        try {
+            clientRequest.writeEntity();
+        } catch (final IOException e) {
+            throw new ProcessingException("Failed to write request entity.", e);
+        }
+        return new BytesContentProvider(outputStream.toByteArray());
+    }
+
+    private ContentProvider getStreamProvider(final ClientRequest clientRequest) {
+        final Object entity = clientRequest.getEntity();
+
+        if (entity == null) {
+            return null;
+        }
+
+        final OutputStreamContentProvider streamContentProvider = new OutputStreamContentProvider();
+        clientRequest.setStreamProvider(new OutboundMessageContext.StreamProvider() {
+            @Override
+            public OutputStream getOutputStream(final int contentLength) throws IOException {
+                return streamContentProvider.getOutputStream();
+            }
+        });
+        return streamContentProvider;
+    }
+
+    private void processContent(final ClientRequest clientRequest, final ContentProvider entity) throws IOException {
+        if (entity == null) {
+            return;
+        }
+
+        final OutputStreamContentProvider streamContentProvider = (OutputStreamContentProvider) entity;
+        try (final OutputStream output = streamContentProvider.getOutputStream()) {
+            clientRequest.writeEntity();
+        }
+    }
+
+    @Override
+    public Future<?> apply(final ClientRequest jerseyRequest, final AsyncConnectorCallback callback) {
+        final Request jettyRequest = translateRequest(jerseyRequest);
+        final Map<String, String> clientHeadersSnapshot = writeOutBoundHeaders(jerseyRequest.getHeaders(), jettyRequest);
+        final ContentProvider entity = getStreamProvider(jerseyRequest);
+        if (entity != null) {
+            jettyRequest.content(entity);
+        }
+        final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+        final Throwable failure;
+        try {
+            final CompletableFuture<ClientResponse> responseFuture =
+                    new CompletableFuture<ClientResponse>().whenComplete(
+                            (clientResponse, throwable) -> {
+                                if (throwable != null && throwable instanceof CancellationException) {
+                                    // take care of future cancellation
+                                    jettyRequest.abort(throwable);
+
+                                }
+                            });
+
+            final AtomicReference<ClientResponse> jerseyResponse = new AtomicReference<>();
+            final ByteBufferInputStream entityStream = new ByteBufferInputStream();
+            jettyRequest.send(new Response.Listener.Adapter() {
+
+                @Override
+                public void onHeaders(final Response jettyResponse) {
+                    HeaderUtils.checkHeaderChanges(clientHeadersSnapshot, jerseyRequest.getHeaders(),
+                            Jetty10Connector.this.getClass().getName(), jerseyRequest.getConfiguration());
+
+                    if (responseFuture.isDone()) {
+                        if (!callbackInvoked.compareAndSet(false, true)) {
+                            return;
+                        }
+                    }
+                    final ClientResponse response = translateResponse(jerseyRequest, jettyResponse, entityStream);
+                    jerseyResponse.set(response);
+                }
+
+                @Override
+                public void onContent(final Response jettyResponse, final ByteBuffer content) {
+                    try {
+                        // content must be consumed before returning from this method.
+
+                        if (content.hasArray()) {
+                            byte[] array = content.array();
+                            byte[] buff = new byte[content.remaining()];
+                            System.arraycopy(array, content.arrayOffset(), buff, 0, content.remaining());
+                            entityStream.put(ByteBuffer.wrap(buff));
+                        } else {
+                            byte[] buff = new byte[content.remaining()];
+                            content.get(buff);
+                            entityStream.put(ByteBuffer.wrap(buff));
+                        }
+                    } catch (final InterruptedException ex) {
+                        final ProcessingException pe = new ProcessingException(ex);
+                        entityStream.closeQueue(pe);
+                        // try to complete the future with an exception
+                        responseFuture.completeExceptionally(pe);
+                        Thread.currentThread().interrupt();
+                    }
+                }
+
+                @Override
+                public void onComplete(final Result result) {
+                    entityStream.closeQueue();
+                    if (!callbackInvoked.get()) {
+                        callback.response(jerseyResponse.get());
+                    }
+                    responseFuture.complete(jerseyResponse.get());
+                }
+
+                @Override
+                public void onFailure(final Response response, final Throwable t) {
+                    entityStream.closeQueue(t);
+                    // try to complete the future with an exception
+                    responseFuture.completeExceptionally(t);
+                    if (callbackInvoked.compareAndSet(false, true)) {
+                        callback.failure(t);
+                    }
+                }
+            });
+            processContent(jerseyRequest, entity);
+            return responseFuture;
+        } catch (final Throwable t) {
+            failure = t;
+        }
+
+        if (callbackInvoked.compareAndSet(false, true)) {
+            callback.failure(failure);
+        }
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        future.completeExceptionally(failure);
+        return future;
+    }
+
+    private static ClientResponse translateResponse(final ClientRequest jerseyRequest,
+                                                    final org.eclipse.jetty.client.api.Response jettyResponse,
+                                                    final NonBlockingInputStream entityStream) {
+        final ClientResponse jerseyResponse = new ClientResponse(Statuses.from(jettyResponse.getStatus()), jerseyRequest);
+        processResponseHeaders(jettyResponse.getHeaders(), jerseyResponse);
+        jerseyResponse.setEntityStream(entityStream);
+        return jerseyResponse;
+    }
+
+    @Override
+    public String getName() {
+        return "Jetty HttpClient " + Jetty.VERSION;
+    }
+
+    @Override
+    public void close() {
+        try {
+            client.stop();
+        } catch (final Exception e) {
+            throw new ProcessingException("Failed to stop the client.", e);
+        }
+    }
+}
+

--- a/components/jax-rs/jersey/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.ConnectorProvider
+++ b/components/jax-rs/jersey/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.ConnectorProvider
@@ -1,0 +1,1 @@
+com.kumuluz.ee.jaxrs.Jetty10ConnectorProvider

--- a/components/jax-ws/cxf/pom.xml
+++ b/components/jax-ws/cxf/pom.xml
@@ -41,32 +41,22 @@
             <version>${cxf.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-tools</artifactId>
+            <version>${jaxws-tools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>${activation.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>java9-modules</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun.xml.ws</groupId>
-                    <artifactId>jaxws-tools</artifactId>
-                    <version>${jaxws-tools.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>activation</artifactId>
-                    <version>${activation.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 
     <build>
         <plugins>

--- a/components/jax-ws/metro/pom.xml
+++ b/components/jax-ws/metro/pom.xml
@@ -30,22 +30,12 @@
             <artifactId>webservices-extra</artifactId>
             <version>${metro.version}</version>
         </dependency>
-    </dependencies>
 
-    <profiles>
-        <profile>
-            <id>java9-modules</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>activation</artifactId>
-                    <version>${activation.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>${activation.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/components/jpa/common/pom.xml
+++ b/components/jpa/common/pom.xml
@@ -21,8 +21,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/components/jpa/eclipselink/pom.xml
+++ b/components/jpa/eclipselink/pom.xml
@@ -21,8 +21,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
 
         <dependency>

--- a/components/jpa/hibernate/pom.xml
+++ b/components/jpa/hibernate/pom.xml
@@ -21,8 +21,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
 
         <dependency>
@@ -68,22 +68,12 @@
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>
-    </dependencies>
 
-    <profiles>
-        <profile>
-            <id>java9-modules</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <version>${jaxb-api.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/components/jpa/hibernate/src/main/java/com/kumuluz/ee/jpa/hibernate/JpaComponent.java
+++ b/components/jpa/hibernate/src/main/java/com/kumuluz/ee/jpa/hibernate/JpaComponent.java
@@ -25,7 +25,6 @@ import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.common.dependencies.EeComponentDef;
 import com.kumuluz.ee.common.dependencies.EeComponentType;
 import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
-import com.kumuluz.ee.jpa.common.PersistenceUnitHolder;
 
 import java.util.logging.Logger;
 
@@ -36,7 +35,7 @@ import java.util.logging.Logger;
 @EeComponentDef(name = "Hibernate", type = EeComponentType.JPA)
 public class JpaComponent implements Component {
 
-    private Logger log = Logger.getLogger(JpaComponent.class.getSimpleName());
+    private final Logger log = Logger.getLogger(JpaComponent.class.getSimpleName());
 
     @Override
     public void init(KumuluzServerWrapper server, EeConfig eeConfig) {

--- a/components/jsf/mojarra/pom.xml
+++ b/components/jsf/mojarra/pom.xml
@@ -21,17 +21,17 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-client-api</artifactId>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.faces</artifactId>
+            <artifactId>jakarta.faces</artifactId>
             <version>${mojarra.version}</version>
         </dependency>
     </dependencies>

--- a/components/jta/common/pom.xml
+++ b/components/jta/common/pom.xml
@@ -33,6 +33,32 @@
             <groupId>org.jboss.weld.module</groupId>
             <artifactId>weld-jta</artifactId>
             <version>${weld.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.3_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.el</groupId>
+                    <artifactId>jboss-el-api_3.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.interceptor</groupId>
+                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
         </dependency>
 
         <dependency>

--- a/components/jta/common/pom.xml
+++ b/components/jta/common/pom.xml
@@ -21,12 +21,12 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.resource</groupId>
-            <artifactId>javax.resource-api</artifactId>
+            <groupId>jakarta.resource</groupId>
+            <artifactId>jakarta.resource-api</artifactId>
         </dependency>
 
         <dependency>

--- a/components/websocket/jetty/pom.xml
+++ b/components/websocket/jetty/pom.xml
@@ -19,15 +19,25 @@
             <groupId>com.kumuluz.ee</groupId>
             <artifactId>kumuluzee-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-servlet-jetty</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>${websocket.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-server-impl</artifactId>
+            <artifactId>websocket-javax-server</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-client-impl</artifactId>
+            <artifactId>websocket-javax-client</artifactId>
             <version>${jetty.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <uel.version>3.0.3</uel.version>
         <weld.version>3.1.8.Final</weld.version>
         <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
-        <jersey.version>2.35-SNAPSHOT</jersey.version>
+        <jersey.version>2.34</jersey.version>
         <jackson.version>2.12.0</jackson.version>
         <metro.version>2.4.1</metro.version>
         <cxf.version>3.4.4</cxf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
 
         <jetty.version>10.0.6</jetty.version>
+        <slf4j.version>2.0.0-alpha1</slf4j.version><!-- the same as used by Jetty -->
         <uel.version>3.0.3</uel.version>
         <weld.version>3.1.8.Final</weld.version>
         <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,32 +29,32 @@
     <url>https://ee.kumuluz.com</url>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <activation.version>1.1.1</activation.version>
-        <jaxws-tools.version>2.3.0.2</jaxws-tools.version>
+        <jaxws-tools.version>2.3.4</jaxws-tools.version>
 
-        <annotations.version>1.3.2</annotations.version>
-        <inject.version>1</inject.version>
-        <interceptor.version>1.2.2</interceptor.version>
-        <servlet.version>3.1.0</servlet.version>
-        <jsp.version>2.3.3</jsp.version>
-        <el.version>3.0.0</el.version>
-        <cdi.version>2.0</cdi.version>
-        <jpa.version>2.2</jpa.version>
-        <jaxrs.version>2.1.1</jaxrs.version>
-        <jaxws.version>2.3.1</jaxws.version>
-        <jsf.version>2.3</jsf.version>
-        <websocket.version>1.1</websocket.version>
-        <beanvalidation.version>2.0.1.Final</beanvalidation.version>
-        <jsonp.version>1.1.4</jsonp.version>
-        <jsonb.version>1.0</jsonb.version>
-        <jta.version>1.3</jta.version>
-        <resource.version>1.7.1</resource.version>
-        <javamail.version>1.6.2</javamail.version>
+        <annotations.version>1.3.5</annotations.version>
+        <inject.version>1.0.3</inject.version>
+        <interceptor.version>1.2.5</interceptor.version>
+        <servlet.version>4.0.4</servlet.version>
+        <jsp.version>2.3.6</jsp.version>
+        <el.version>3.0.3</el.version>
+        <cdi.version>2.0.2</cdi.version>
+        <jpa.version>2.2.3</jpa.version>
+        <jaxrs.version>2.1.6</jaxrs.version>
+        <jaxws.version>2.3.3</jaxws.version>
+        <jsf.version>2.3.2</jsf.version>
+        <websocket.version>1.1.2</websocket.version>
+        <beanvalidation.version>2.0.2</beanvalidation.version>
+        <jsonp.version>1.1.6</jsonp.version>
+        <jsonb.version>1.0.2</jsonb.version>
+        <jta.version>1.3.3</jta.version>
+        <resource.version>1.7.4</resource.version>
+        <javamail.version>1.6.7</javamail.version>
 
         <jandex.version>2.2.2.Final</jandex.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
@@ -73,17 +73,17 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
 
-        <jetty.version>9.4.35.v20201120</jetty.version>
-        <uel.version>3.0.0</uel.version>
+        <jetty.version>10.0.6</jetty.version>
+        <uel.version>3.0.3</uel.version>
         <weld.version>3.1.8.Final</weld.version>
-        <hibernate.validator.version>6.1.6.Final</hibernate.validator.version>
-        <jersey.version>2.32</jersey.version>
+        <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
+        <jersey.version>2.35-SNAPSHOT</jersey.version>
         <jackson.version>2.12.0</jackson.version>
         <metro.version>2.4.1</metro.version>
-        <cxf.version>3.2.14</cxf.version>
-        <hibernate.version>5.4.26.Final</hibernate.version>
+        <cxf.version>3.4.4</cxf.version>
+        <hibernate.version>5.5.7.Final</hibernate.version>
         <eclipselink.version>2.7.8</eclipselink.version>
-        <mojarra.version>2.4.0</mojarra.version>
+        <mojarra.version>2.3.16</mojarra.version>
         <jsonp-impl.version>1.1.4</jsonp-impl.version>
         <yasson.version>1.0.8</yasson.version>
         <narayana.version>5.10.6.Final</narayana.version>
@@ -367,98 +367,98 @@
 
             <!-- Java EE specification dependencies-->
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
                 <version>${annotations.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
                 <version>${inject.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.interceptor</groupId>
-                <artifactId>javax.interceptor-api</artifactId>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
                 <version>${interceptor.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
                 <version>${servlet.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>javax.servlet.jsp-api</artifactId>
+                <groupId>jakarta.servlet.jsp</groupId>
+                <artifactId>jakarta.servlet.jsp-api</artifactId>
                 <version>${jsp.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
                 <version>${el.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${cdi.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
                 <version>${jpa.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${jaxrs.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.ws</groupId>
-                <artifactId>jaxws-api</artifactId>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
                 <version>${jaxws.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.faces</groupId>
-                <artifactId>javax.faces-api</artifactId>
+                <groupId>jakarta.faces</groupId>
+                <artifactId>jakarta.faces-api</artifactId>
                 <version>${jsf.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.websocket</groupId>
-                <artifactId>javax.websocket-api</artifactId>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-api</artifactId>
                 <version>${websocket.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.websocket</groupId>
-                <artifactId>javax.websocket-client-api</artifactId>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-client-api</artifactId>
                 <version>${websocket.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
                 <version>${beanvalidation.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.json</groupId>
-                <artifactId>javax.json-api</artifactId>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
                 <version>${jsonp.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.json.bind</groupId>
-                <artifactId>javax.json.bind-api</artifactId>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
                 <version>${jsonb.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.transaction</groupId>
-                <artifactId>javax.transaction-api</artifactId>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
                 <version>${jta.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.resource</groupId>
-                <artifactId>javax.resource-api</artifactId>
+                <groupId>jakarta.resource</groupId>
+                <artifactId>jakarta.resource-api</artifactId>
                 <version>${resource.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.mail</groupId>
-                <artifactId>javax.mail-api</artifactId>
+                <groupId>jakarta.mail</groupId>
+                <artifactId>jakarta.mail-api</artifactId>
                 <version>${javamail.version}</version>
             </dependency>
 

--- a/servlet/jetty/pom.xml
+++ b/servlet/jetty/pom.xml
@@ -65,16 +65,10 @@
             <artifactId>http2-http-client-transport</artifactId>
             <version>${jetty.version}</version>
         </dependency>
-
-        <dependency><!-- TODO -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.31</version>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.31</version>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>

--- a/servlet/jetty/pom.xml
+++ b/servlet/jetty/pom.xml
@@ -27,6 +27,16 @@
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-java-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-java-client</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
             <version>${jetty.version}</version>
         </dependency>
@@ -80,49 +90,21 @@
             </exclusions>
         </dependency>
 
+        <dependency><!-- TODO -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.31</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.31</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>legacy-alpn</id>
-            <activation>
-                <jdk>[1.8,9)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-alpn-openjdk8-server</artifactId>
-                    <version>${jetty.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-alpn-openjdk8-client</artifactId>
-                    <version>${jetty.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>native-alpn</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-alpn-java-server</artifactId>
-                    <version>${jetty.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-alpn-java-client</artifactId>
-                    <version>${jetty.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/servlet/jetty/pom.xml
+++ b/servlet/jetty/pom.xml
@@ -66,30 +66,6 @@
             <version>${jetty.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.glassfish.jersey.connectors</groupId>
-            <artifactId>jersey-jetty-connector</artifactId>
-            <version>${jersey.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency><!-- TODO -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyFactory.java
@@ -24,20 +24,14 @@ import com.kumuluz.ee.common.config.ServerConfig;
 import com.kumuluz.ee.common.config.ServerConnectorConfig;
 import com.kumuluz.ee.common.utils.StringUtils;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
-import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.HTTP2Cipher;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
-import org.eclipse.jetty.plus.webapp.EnvConfiguration;
-import org.eclipse.jetty.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.server.*;
-import org.eclipse.jetty.util.log.JavaUtilLog;
-import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
-import org.eclipse.jetty.webapp.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,11 +55,8 @@ public class JettyFactory {
 
     public Server create() {
 
-        Log.setLog(new JavaUtilLog());
-
         Server server = new Server(createThreadPool());
 
-        server.addBean(createClassList());
         server.setStopAtShutdown(true);
         server.setConnectors(createConnectors(server));
 
@@ -167,7 +158,7 @@ public class JettyFactory {
 
             HttpConnectionFactory http = new HttpConnectionFactory(httpsConfiguration);
 
-            SslContextFactory sslContextFactory = new SslContextFactory.Server();
+            SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
             sslContextFactory.setKeyStorePath(httpsConfig.getKeystorePath());
             sslContextFactory.setKeyStorePassword(httpsConfig.getKeystorePassword());
 
@@ -226,21 +217,5 @@ public class JettyFactory {
         LOG.info(String.format("Starting KumuluzEE on port(s): %s", ports));
 
         return connectors.toArray(new ServerConnector[0]);
-    }
-
-    private Configuration.ClassList createClassList() {
-
-        Configuration.ClassList classList = new Configuration.ClassList(new String[0]);
-
-        classList.add(AnnotationConfiguration.class.getName());
-        classList.add(WebInfConfiguration.class.getName());
-        classList.add(WebXmlConfiguration.class.getName());
-        classList.add(MetaInfConfiguration.class.getName());
-        classList.add(FragmentConfiguration.class.getName());
-        classList.add(JettyWebXmlConfiguration.class.getName());
-        classList.add(EnvConfiguration.class.getName());
-        classList.add(PlusConfiguration.class.getName());
-
-        return classList;
     }
 }

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.server.handler.SecuredRedirectHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlet.listener.ELContextCleaner;
 import org.eclipse.jetty.webapp.*;
 
 import javax.naming.NamingException;
@@ -52,6 +53,7 @@ import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -182,6 +184,11 @@ public class JettyServletServer implements ServletServer {
         if (Boolean.TRUE.equals(serverConfig.getEtags())) {
             appContext.setInitParameter(JettyAttributes.etags, "true");
         }
+
+        // Since ELContextCleaner cannot perform reflective access to BeanELResolver it logs a warning before container
+        // shutdown. Because Jetty is running in embedded mode, this purge is not necessary and the warning is irrelevant.
+        Logger.getLogger(ELContextCleaner.class.getName()).setLevel(Level.SEVERE);
+
         log.info("Starting KumuluzEE with context root '" + serverConfig.getContextPath() + "'");
 
         GzipConfig gzipConfig = serverConfig.getGzip();

--- a/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
+++ b/servlet/jetty/src/main/java/com/kumuluz/ee/jetty/JettyServletServer.java
@@ -25,14 +25,16 @@ import com.kumuluz.ee.common.attributes.ClasspathAttributes;
 import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.common.config.GzipConfig;
 import com.kumuluz.ee.common.config.ServerConfig;
-import com.kumuluz.ee.common.config.ServerConnectorConfig;
 import com.kumuluz.ee.common.dependencies.EeComponentType;
 import com.kumuluz.ee.common.dependencies.ServerDef;
 import com.kumuluz.ee.common.exceptions.KumuluzServerException;
 import com.kumuluz.ee.common.servlet.ServletWrapper;
 import com.kumuluz.ee.common.utils.ResourceUtils;
+import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.plus.jndi.Resource;
 import org.eclipse.jetty.plus.jndi.Transaction;
+import org.eclipse.jetty.plus.webapp.EnvConfiguration;
+import org.eclipse.jetty.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerList;
@@ -40,7 +42,7 @@ import org.eclipse.jetty.server.handler.SecuredRedirectHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.*;
 
 import javax.naming.NamingException;
 import javax.servlet.DispatcherType;
@@ -48,6 +50,7 @@ import javax.servlet.Filter;
 import javax.servlet.Servlet;
 import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
+import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -59,7 +62,7 @@ import java.util.regex.Pattern;
 @ServerDef(value = "Jetty", provides = {EeComponentType.SERVLET})
 public class JettyServletServer implements ServletServer {
 
-    private Logger log = Logger.getLogger(JettyServletServer.class.getSimpleName());
+    private final Logger log = Logger.getLogger(JettyServletServer.class.getSimpleName());
 
     private Server server;
 
@@ -126,15 +129,21 @@ public class JettyServletServer implements ServletServer {
 
         appContext = new WebAppContext();
 
+        appContext.setConfigurationClasses(createConfigurations());
+
+        try {
+            appContext.setClassLoader(getClass().getClassLoader());
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to set custom classloader for Jetty", e);
+        }
+
         if (ResourceUtils.isRunningInJar()) {
             appContext.setAttribute(JettyAttributes.jarPattern, ClasspathAttributes.jar);
 
-            appContext.setExtraClasspath(JettyJarClasspathUtil.getExtraClasspath(scanLibraries));
-
             try {
-                appContext.setClassLoader(getClass().getClassLoader());
-            } catch (Exception e) {
-                throw new IllegalStateException("Unable to set custom classloader for Jetty", e);
+                appContext.setExtraClasspath(JettyJarClasspathUtil.getExtraClasspath(scanLibraries));
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to set extra classpath for Jetty", e);
             }
         } else {
             StringBuilder explodedClasspath = new StringBuilder(ClasspathAttributes.exploded);
@@ -151,7 +160,7 @@ public class JettyServletServer implements ServletServer {
                 }
             }
 
-            log.fine("Using classpath scanning regex: " + explodedClasspath.toString());
+            log.fine("Using classpath scanning regex: " + explodedClasspath);
             appContext.setAttribute(JettyAttributes.jarPattern, explodedClasspath.toString());
         }
 
@@ -198,8 +207,6 @@ public class JettyServletServer implements ServletServer {
                     gzipHandler.setIncludedMimeTypes(gzipConfig.getIncludedMimeTypes().toArray(new String[0]));
                 if(gzipConfig.getExcludedMimeTypes() != null)
                     gzipHandler.setExcludedMimeTypes(gzipConfig.getExcludedMimeTypes().toArray(new String[0]));
-                if(gzipConfig.getExcludedAgentPatterns() != null)
-                    gzipHandler.setExcludedAgentPatterns(gzipConfig.getExcludedAgentPatterns().toArray(new String[0]));
                 if(gzipConfig.getExcludedPaths() != null)
                     gzipHandler.setExcludedPaths(gzipConfig.getExcludedPaths().toArray(new String[0]));
                 if(gzipConfig.getIncludedPaths() != null)
@@ -366,5 +373,22 @@ public class JettyServletServer implements ServletServer {
     private JettyFactory createJettyFactory() {
 
         return new JettyFactory(serverConfig);
+    }
+
+    private List<String> createConfigurations() {
+
+        List<String> configurations = new ArrayList<>();
+
+        configurations.add(WebAppConfiguration.class.getName());
+        configurations.add(AnnotationConfiguration.class.getName());
+        configurations.add(WebInfConfiguration.class.getName());
+        configurations.add(WebXmlConfiguration.class.getName());
+        configurations.add(MetaInfConfiguration.class.getName());
+        configurations.add(FragmentConfiguration.class.getName());
+        configurations.add(JettyWebXmlConfiguration.class.getName());
+        configurations.add(EnvConfiguration.class.getName());
+        configurations.add(PlusConfiguration.class.getName());
+
+        return configurations;
     }
 }

--- a/servlet/jetty/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.ConnectorProvider
+++ b/servlet/jetty/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.ConnectorProvider
@@ -1,1 +1,0 @@
-org.glassfish.jersey.jetty.connector.JettyConnectorProvider


### PR DESCRIPTION
Changes:

- Upgraded from Jetty 9 to Jetty 10
- Removed excludedAgentPatterns from gzip config since it was removed from Jetty
- Migrated dependencies from JavaEE 8 to JakartaEE 8
- Dropped support for Java 1.8, minimum version now is Java 11
- Updated JAX-WS annotation procesor in order to support some edge cases
- Pruned dependency tree