### PR TITLE
Added support for multi release JAR files

### DIFF
--- a/tools/loader/src/main/java/com/kumuluz/ee/loader/EeClassLoader.java
+++ b/tools/loader/src/main/java/com/kumuluz/ee/loader/EeClassLoader.java
@@ -41,6 +41,7 @@ import java.util.jar.JarFile;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.zip.ZipFile;
 
 /**
  * @author Benjamin Kastelic
@@ -272,7 +273,7 @@ public class EeClassLoader extends ClassLoader {
                                 ? new CodeSource(url, csParent.getCodeSigners())
                                 : new CodeSource(url, certParent);
                         ProtectionDomain pdChild = new ProtectionDomain(csChild, pdParent.getPermissions(), pdParent.getClassLoader(), pdParent.getPrincipals());
-                        loadJar(new JarFileInfo(new JarFile(tempFile), jarEntryInfo.getName(), jarFileInfo, pdChild, tempFile));
+                        loadJar(new JarFileInfo(new JarFile(tempFile, true, ZipFile.OPEN_READ, JarFile.runtimeVersion()), jarEntryInfo.getName(), jarFileInfo, pdChild, tempFile));
                     } catch (IOException e) {
                         throw new RuntimeException(String.format("Cannot load jar entries from jar %s", je.getName().toLowerCase()), e);
                     } catch (EeClassLoaderException e) {


### PR DESCRIPTION
Changed the JarFile constructor to the one with a version argument in order to support multi release Jar files as it is done in `jdk.internal.loader.URLClassPath#getJarFile`

This fixes issue #205 