### PR TITLE
Added support for Java 16 and 17

### DIFF
--- a/.github/workflows/kumuluzee-ci.yml
+++ b/.github/workflows/kumuluzee-ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: ['11', '15']
+        java-version: ['11', '17']
 
     steps:
       - name: Checkout code

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <metro.version>2.4.6</metro.version>
         <cxf.version>3.4.4</cxf.version>
         <hibernate.version>5.5.7.Final</hibernate.version>
-        <eclipselink.version>2.7.8</eclipselink.version>
+        <eclipselink.version>2.7.9</eclipselink.version>
         <mojarra.version>2.3.16</mojarra.version>
         <jsonp-impl.version>1.1.4</jsonp-impl.version>
         <yasson.version>1.0.8</yasson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <activation.version>1.1.1</activation.version>
-        <jaxws-tools.version>2.3.4</jaxws-tools.version>
+        <jaxws-tools.version>2.3.5</jaxws-tools.version>
 
         <annotations.version>1.3.5</annotations.version>
         <inject.version>1.0.3</inject.version>
@@ -80,7 +80,7 @@
         <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
         <jersey.version>2.34</jersey.version>
         <jackson.version>2.12.0</jackson.version>
-        <metro.version>2.4.1</metro.version>
+        <metro.version>2.4.6</metro.version>
         <cxf.version>3.4.4</cxf.version>
         <hibernate.version>5.5.7.Final</hibernate.version>
         <eclipselink.version>2.7.8</eclipselink.version>

--- a/tools/loader/src/main/java/com/kumuluz/ee/loader/EeClassLoader.java
+++ b/tools/loader/src/main/java/com/kumuluz/ee/loader/EeClassLoader.java
@@ -41,6 +41,7 @@ import java.util.jar.JarFile;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.zip.ZipFile;
 
 /**
  * @author Benjamin Kastelic
@@ -111,7 +112,8 @@ public class EeClassLoader extends ClassLoader {
         File mainJarFile = new File(mainJarURLString);
 
         try {
-            jarFileInfo = new JarFileInfo(new JarFile(mainJarFile), mainJarFile.getName(), null, protectionDomain, null);
+            jarFileInfo = new JarFileInfo(new JarFile(mainJarFile, true, ZipFile.OPEN_READ, JarFile.runtimeVersion()),
+                    mainJarFile.getName(), null, protectionDomain, null);
 
             debug(String.format("Loading from main JAR: '%s' PROTOCOL: '%s'", mainJarURLString, protocol));
         } catch (IOException e) {
@@ -272,7 +274,8 @@ public class EeClassLoader extends ClassLoader {
                                 ? new CodeSource(url, csParent.getCodeSigners())
                                 : new CodeSource(url, certParent);
                         ProtectionDomain pdChild = new ProtectionDomain(csChild, pdParent.getPermissions(), pdParent.getClassLoader(), pdParent.getPrincipals());
-                        loadJar(new JarFileInfo(new JarFile(tempFile), jarEntryInfo.getName(), jarFileInfo, pdChild, tempFile));
+                        loadJar(new JarFileInfo(new JarFile(tempFile, true, ZipFile.OPEN_READ, JarFile.runtimeVersion()),
+                                jarEntryInfo.getName(), jarFileInfo, pdChild, tempFile));
                     } catch (IOException e) {
                         throw new RuntimeException(String.format("Cannot load jar entries from jar %s", je.getName().toLowerCase()), e);
                     } catch (EeClassLoaderException e) {

--- a/tools/maven-plugin/src/main/java/com/kumuluz/ee/maven/plugin/AbstractPackageMojo.java
+++ b/tools/maven-plugin/src/main/java/com/kumuluz/ee/maven/plugin/AbstractPackageMojo.java
@@ -34,6 +34,7 @@ import java.nio.file.*;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.jar.JarFile;
+import java.util.zip.ZipFile;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -92,7 +93,7 @@ public abstract class AbstractPackageMojo extends AbstractCopyDependenciesMojo {
 
             Files.copy(loaderJarFile, tmpJar, StandardCopyOption.REPLACE_EXISTING);
 
-            JarFile loaderJar = new JarFile(tmpJar.toFile());
+            JarFile loaderJar = new JarFile(tmpJar.toFile(), true, ZipFile.OPEN_READ, JarFile.runtimeVersion());
 
             loaderJar.stream().parallel()
                     .filter(loaderJarEntry -> loaderJarEntry.getName().toLowerCase().endsWith(CLASS_SUFFIX))


### PR DESCRIPTION
Changes:

- upped jax-ws and EclipseLink versions
- updated JAR loading using the Java 9 constructor, in order to support multi-release jars when running in UberJAR