### PR TITLE
Additional port configuration through environment variables

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/configuration/enums/PortEnvironmentVariables.java
+++ b/common/src/main/java/com/kumuluz/ee/configuration/enums/PortEnvironmentVariables.java
@@ -1,0 +1,26 @@
+package com.kumuluz.ee.configuration.enums;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+
+public enum PortEnvironmentVariables {
+
+    /*
+     * The values enumerated on top will have the highest priority, i.e. if multiple env variables are
+     * defined, the one enumerated in this file on top will be the one to be used
+     */
+    AZURE_SERVERLESS_PORT_ENV_VAR("FUNCTIONS_CUSTOMHANDLER_PORT"),
+    SHORT_PORT_ENV("PORT");
+
+    private final String envVarName;
+
+    PortEnvironmentVariables(String envVarName) {
+        this.envVarName = envVarName;
+    }
+
+    public static Stream<String> stream() {
+        return Stream.of(PortEnvironmentVariables.values())
+                .sorted(Collections.reverseOrder())
+                .map(var -> var.envVarName);
+    }
+}

--- a/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
+++ b/core/src/main/java/com/kumuluz/ee/factories/EeConfigFactory.java
@@ -33,6 +33,7 @@ import com.kumuluz.ee.common.config.ServerConnectorConfig;
 import com.kumuluz.ee.common.config.XaDataSourceConfig;
 import com.kumuluz.ee.common.utils.EnvUtils;
 import com.kumuluz.ee.common.utils.StringUtils;
+import com.kumuluz.ee.configuration.enums.PortEnvironmentVariables;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 
 import java.util.ArrayList;
@@ -47,8 +48,6 @@ import java.util.stream.Stream;
  * @since 2.4.0
  */
 public class EeConfigFactory {
-
-    private static final String PORT_ENV = "PORT";
 
     public static EeConfig buildEeConfig() {
 
@@ -95,7 +94,9 @@ public class EeConfigFactory {
                 createServerConnectorConfigBuilder("kumuluzee.server.http",
                         ServerConnectorConfig.DEFAULT_HTTP_PORT);
 
-        EnvUtils.getEnvAsInteger(PORT_ENV, httpBuilder::port);
+        PortEnvironmentVariables.stream().forEach(portEnvVar ->
+            EnvUtils.getEnvAsInteger(portEnvVar, httpBuilder::port)
+        );
 
         ServerConnectorConfig.Builder httpsBuilder =
                 createServerConnectorConfigBuilder("kumuluzee.server.https",


### PR DESCRIPTION
Check the environment variables for the `FUNCTIONS_CUSTOMHANDLER_PORT` one, which is set by the Azure functions host when starting the kumuluzee container. With this addition, the core becomes fit to be used on Azure Functions